### PR TITLE
Issue 1173 changes to edges

### DIFF
--- a/code/kg2/create_indexes_constraints.py
+++ b/code/kg2/create_indexes_constraints.py
@@ -55,7 +55,8 @@ def create_index(label_list, property_name):
     # For every label in the label list, create an index
     # on the given property name
     for label in label_list:
-        index_query = "CREATE INDEX ON :`" + label + "` (" + property_name + ")"
+        if label.find(":") < 0:  # CREATE INDEX ON :BFO:0000050 (relation_label) gives error
+            index_query = "CREATE INDEX ON :" + label + " (" + property_name + ")"
         run_query(index_query)
 
 

--- a/code/kg2/filter_kg_and_remap_predicates.py
+++ b/code/kg2/filter_kg_and_remap_predicates.py
@@ -19,14 +19,15 @@ import pprint
 import sys
 from datetime import datetime
 
-# - check for any input predicates that occur twice in the predicate-remap.yaml file
+# - check for any input relation_labels that occur twice in the predicate-remap.yaml file
+# - rename script something like "filter_kg_and_remap_relation_labels.py"
 # - need to detect the command "keep" in the YAML file
 # - drop edges with 'NEGATION' ?
 # - *don't* merge two edges if at least one of them has nonempty publication_info
 # - change 'xref' to skos:closeMatch (skos)
 # - drop any edge if it is in between two SnoMedCT nodes (optionally; use command-line option)
 # - programmatically generate list of "keep" lines to add to the YAML file so all 1,100
-#   distinct predicates are represented in the file
+#   distinct relation_labels are represented in the file
 # - note (somehow) if a relationship has been inverted, in the "orig_relation_curie" field
 
 
@@ -76,10 +77,10 @@ if __name__ == '__main__':
             print('processing edge ' + str(edge_ctr) + ' out of ' + str(len(graph['edges'])))
         if drop_negated and edge_dict['negated']:
             continue
-        predicate = edge_dict['predicate']
-        simplified_predicate = predicate
+        relation_label = edge_dict['relation_label']
+        predicate_label = relation_label
         relation_curie = edge_dict['relation']
-        simplified_relation_curie = relation_curie
+        predicate_curie = relation_curie
         if record_of_relation_curie_occurrences.get(relation_curie, None) is not None:
             record_of_relation_curie_occurrences[relation_curie] = True
             pred_remap_info = predicate_remap_config.get(relation_curie, None)
@@ -106,26 +107,26 @@ if __name__ == '__main__':
                 else:
                     get_new_rel_info = True
         if get_new_rel_info:
-            simplified_predicate = remap_subinfo[0]
-            simplified_relation_curie = remap_subinfo[1]
+            predicate_label = remap_subinfo[0]
+            predicate_curie = remap_subinfo[1]
         if invert:
-            edge_dict['predicate'] = 'INVERTED:' + predicate
+            edge_dict['relation_label'] = 'INVERTED:' + relation_label
             new_object = edge_dict['subject']
             edge_dict['subject'] = edge_dict['object']
             edge_dict['object'] = new_object
-        edge_dict['simplified_predicate'] = simplified_predicate
+        edge_dict['predicate_label'] = predicate_label
         if drop_self_edges_except is not None and \
            edge_dict['subject'] == edge_dict['object'] and \
-           simplified_predicate not in drop_self_edges_except:
+           predicate_label not in drop_self_edges_except:
             continue  # see issue 743
-        edge_dict['simplified_relation'] = simplified_relation_curie
-        if simplified_relation_curie not in nodes_dict:
-            simplified_relation_curie_prefix = simplified_relation_curie.split(':')[0]
-            simplified_relation_uri_prefix = curie_to_uri_expander(simplified_relation_curie_prefix + ':')
-            if simplified_relation_uri_prefix == simplified_relation_curie_prefix:
-                relation_curies_not_in_nodes.add(simplified_relation_curie)
+        edge_dict['predicate'] = predicate_curie
+        if predicate_curie not in nodes_dict:
+            predicate_curie_prefix = predicate_curie.split(':')[0]
+            predicate_uri_prefix = curie_to_uri_expander(predicate_curie_prefix + ':')
+            if predicate_uri_prefix == predicate_curie_prefix:
+                relation_curies_not_in_nodes.add(predicate_curie)
         edge_dict['provided_by'] = [edge_dict['provided_by']]
-        edge_key = edge_dict['subject'] + ' /// ' + simplified_predicate + ' /// ' + edge_dict['object']
+        edge_key = edge_dict['subject'] + ' /// ' + predicate_label + ' /// ' + edge_dict['object']
         existing_edge = new_edges.get(edge_key, None)
         if existing_edge is not None:
             existing_edge['provided_by'] = sorted(list(set(existing_edge['provided_by'] + edge_dict['provided_by'])))

--- a/code/kg2/kg2_util.py
+++ b/code/kg2/kg2_util.py
@@ -629,7 +629,7 @@ def make_edge(subject_id: str,
 
     return {'subject': subject_id,
             'object': object_id,
-            'predicate': predicate_label,
+            'relation_label': predicate_label,
             'relation': relation_curie,
             'negated': False,
             'publications': [],

--- a/code/kg2/kg_json_to_tsv.py
+++ b/code/kg2/kg_json_to_tsv.py
@@ -76,7 +76,7 @@ def check_all_edges_have_same_set(edgekeys_list):
     :param edgekeys_list: A list containing keys for an edge
     """
     # Supported_ls is a list of properties that edges can have
-    supported_ls = ["predicate",
+    supported_ls = ["relation_label",
                     "negated",
                     "object",
                     "provided_by",
@@ -85,11 +85,11 @@ def check_all_edges_have_same_set(edgekeys_list):
                     "relation",
                     "subject",
                     "update_date",
-                    "simplified_relation",
-                    "simplified_predicate"]
+                    "predicate",
+                    "predicate_label"]
     for edgelabel in edgekeys_list:
         if edgelabel not in supported_ls:
-            raise ValueError("predicate not in supported list: " + edgelabel)
+            raise ValueError("relation_label not in supported list: " + edgelabel)
 
 
 def truncate_node_synonyms_if_too_large(node_synonym_field, node_id):
@@ -150,7 +150,7 @@ def nodes(graph, output_file_location):
         single_loop += 1
         if single_loop == 1:
             nodekeys_official = list(sorted(node.keys()))
-            nodekeys_official.append("category")
+            nodekeys_official.append("category_label")
 
     for node in nodes:
         # Inrease node counter by one each loop
@@ -158,7 +158,7 @@ def nodes(graph, output_file_location):
 
         # Add all node property labels to a list in the same order
         nodekeys = list(sorted(node.keys()))
-        nodekeys.append("category")
+        nodekeys.append("category_label")
 
         # Create list for values of node properties to be added to
         vallist = []
@@ -256,9 +256,9 @@ def edges(graph, output_file_location):
         edgekeys = list(sorted(edge.keys()))
         check_all_edges_have_same_set(edgekeys)
 
-        # Add an extra property of "predicate" to the list so that predicates
+        # Add an extra property of "relation_label" to the list so that relation_labels
         # can be a property and a label
-        edgekeys.append('simplified_relation')
+        edgekeys.append('predicate_label')
         edgekeys.append('subject')
         edgekeys.append('object')
 
@@ -273,7 +273,7 @@ def edges(graph, output_file_location):
                 value = limit_publication_info_size(key, value)
             elif key == 'provided_by':
                 value = str(value).replace("', '", "; ").replace("['", "").replace("']", "")
-            elif key == 'predicate':  # fix for issue number 473 (hyphens in predicates)
+            elif key == 'relation_label':  # fix for issue number 473 (hyphens in relation_labels)
                 value = value.replace('-', '_').replace('(', '').replace(')', '')
             elif key == 'publications':
                 value = str(value).replace("', '", "; ").replace("'", "").replace("[", "").replace("]", "")
@@ -283,7 +283,7 @@ def edges(graph, output_file_location):
         # But only for the first edge
         if loop == 1:
             edgekeys = no_space('provided_by', edgekeys, 'provided_by:string[]')
-            edgekeys = no_space('simplified_relation', edgekeys, 'predicate:TYPE')
+            edgekeys = no_space('predicate', edgekeys, 'relation_label:TYPE')
             edgekeys = no_space('subject', edgekeys, ':START_ID')
             edgekeys = no_space('object', edgekeys, ':END_ID')
             edgekeys = no_space('publications', edgekeys, "publications:string[]")

--- a/code/kg2/kg_json_to_tsv.py
+++ b/code/kg2/kg_json_to_tsv.py
@@ -150,7 +150,7 @@ def nodes(graph, output_file_location):
         single_loop += 1
         if single_loop == 1:
             nodekeys_official = list(sorted(node.keys()))
-            nodekeys_official.append("category_label")
+            nodekeys_official.append("category")
 
     for node in nodes:
         # Inrease node counter by one each loop
@@ -158,7 +158,7 @@ def nodes(graph, output_file_location):
 
         # Add all node property labels to a list in the same order
         nodekeys = list(sorted(node.keys()))
-        nodekeys.append("category_label")
+        nodekeys.append("category")
 
         # Create list for values of node properties to be added to
         vallist = []
@@ -256,9 +256,9 @@ def edges(graph, output_file_location):
         edgekeys = list(sorted(edge.keys()))
         check_all_edges_have_same_set(edgekeys)
 
-        # Add an extra property of "relation_label" to the list so that relation_labels
+        # Add an extra property of "predicate" to the list so that predicates
         # can be a property and a label
-        edgekeys.append('predicate_label')
+        edgekeys.append('predicate')
         edgekeys.append('subject')
         edgekeys.append('object')
 
@@ -283,7 +283,7 @@ def edges(graph, output_file_location):
         # But only for the first edge
         if loop == 1:
             edgekeys = no_space('provided_by', edgekeys, 'provided_by:string[]')
-            edgekeys = no_space('predicate', edgekeys, 'relation_label:TYPE')
+            edgekeys = no_space('predicate', edgekeys, 'predicate:TYPE')
             edgekeys = no_space('subject', edgekeys, ':START_ID')
             edgekeys = no_space('object', edgekeys, ':END_ID')
             edgekeys = no_space('publications', edgekeys, "publications:string[]")

--- a/code/kg2/report_stats_on_json_kg.py
+++ b/code/kg2/report_stats_on_json_kg.py
@@ -92,22 +92,22 @@ def count_edges_by_source(edges: list):
 
 
 def count_edges_by_predicate_curie(edges: list):
-    curie_field = 'relation' if not args.use_simplified_predicates else 'simplified_relation'
+    curie_field = 'relation' if not args.use_simplified_predicates else 'predicate'
     return collections.Counter([edge[curie_field] for edge in edges])
 
 
 def count_edges_by_predicate_type(edges: list):
-    label_field = 'predicate' if not args.use_simplified_predicates else 'simplified_predicate'
+    label_field = 'relation_label' if not args.use_simplified_predicates else 'predicate_label'
     return collections.Counter([edge[label_field] for edge in edges])
 
 
 def count_edges_by_predicate_curie_prefix(edges: list):
-    curie_field = 'relation' if not args.use_simplified_predicates else 'simplified_relation'
+    curie_field = 'relation' if not args.use_simplified_predicates else 'predicate'
     return collections.Counter([get_prefix_from_curie_id(edge[curie_field]) for edge in edges])
 
 
 def count_predicates_by_predicate_curie_prefix(edges: list):
-    curie_field = 'relation' if not args.use_simplified_predicates else 'simplified_relation'
+    curie_field = 'relation' if not args.use_simplified_predicates else 'predicate'
     unique_relation_curies = set([edge[curie_field] for edge in edges])
     return collections.Counter([get_prefix_from_curie_id(curie) for curie in unique_relation_curies])
 
@@ -115,7 +115,7 @@ def count_predicates_by_predicate_curie_prefix(edges: list):
 def count_types_of_pairs_of_curies_for_xrefs(edges: list):
     prefix_pairs_list = list()
     for edge in edges:
-        if edge['predicate'] == 'xref' or edge['predicate'] == 'close_match':
+        if edge['relation_label'] == 'xref' or edge['relation_label'] == 'close_match':
             subject_curie = edge['subject']
             subject_prefix = get_prefix_from_curie_id(subject_curie)
             object_curie = edge['object']
@@ -128,7 +128,7 @@ def count_types_of_pairs_of_curies_for_xrefs(edges: list):
 def count_types_of_pairs_of_curies_for_equivs(edges: list):
     prefix_pairs_list = list()
     for edge in edges:
-        if edge['predicate'] == kg2_util.EDGE_LABEL_OWL_SAME_AS:
+        if edge['relation_label'] == kg2_util.EDGE_LABEL_OWL_SAME_AS:
             subject_curie = edge['subject']
             subject_prefix = get_prefix_from_curie_id(subject_curie)
             object_curie = edge['object']

--- a/code/kg2/report_stats_on_neo4j_kg.py
+++ b/code/kg2/report_stats_on_neo4j_kg.py
@@ -115,8 +115,8 @@ def count_edges_by_predicate_curie(session):
 
 
 def count_edges_by_predicate_type(session):
-    res = session.run('MATCH (n)-[r]->() RETURN r.predicate AS PredicateType,\
-    count(r) AS NumberofRelationships ORDER BY r.predicate')
+    res = session.run('MATCH (n)-[r]->() RETURN r.relation_label AS PredicateType,\
+    count(r) AS NumberofRelationships ORDER BY r.relation_label')
     return {record[0]: record[1] for record in res.records()}
 
 
@@ -129,7 +129,7 @@ def count_edges_by_predicate_curie_prefix(session):
 
 def count_predicates_by_predicate_curie_prefix(session):
     res = session.run('MATCH (n)-[r]->() WITH split(r.relation, ":")[0]\
-    AS CuriePrefix, count(DISTINCT r.predicate) AS Count RETURN DISTINCT\
+    AS CuriePrefix, count(DISTINCT r.relation_label) AS Count RETURN DISTINCT\
     CuriePrefix, Count')
     return {record[0]: record[1] for record in res.records()}
 

--- a/code/kg2/rtx_kg1_neo4j_to_kg_json.py
+++ b/code/kg2/rtx_kg1_neo4j_to_kg_json.py
@@ -198,6 +198,7 @@ if __name__ == '__main__':
         del edge_dict['source_node_uuid']
         del edge_dict['target_node_uuid']
         predicate_label = edge_dict['relation']
+        edge_dict['relation_label'] = predicate_label
         del edge_dict['relation']
         relation_curie = kg2_util.predicate_label_to_curie(predicate_label,
                                                            KG1_RELATION_CURIE_PREFIX)
@@ -222,7 +223,6 @@ if __name__ == '__main__':
                   file=sys.stderr)
         if edge_dict.get('predicate', None) is not None:
             del edge_dict['predicate']
-        edge_dict['predicate'] = predicate_label
         probability = edge_dict.get('probability', None)
         if probability is not None:
             publication_info_dict = {'publication date': None,

--- a/code/kg2/semmeddb_tuple_list_json_to_kg_json.py
+++ b/code/kg2/semmeddb_tuple_list_json_to_kg_json.py
@@ -214,10 +214,10 @@ if __name__ == '__main__':
         for rel_to_make in get_rels_to_make_for_row(subject_cui_str, object_cui_str, predicate, remapped_cuis):
             subject_curie = rel_to_make[0]
             object_curie = rel_to_make[1]
-            edge_label = rel_to_make[2]
+            relation_label = rel_to_make[2]
             # Exclude self-edges for certain types of predicates
-            if subject_curie != object_curie or edge_label.lower() not in EDGE_LABELS_EXCLUDE_FOR_LOOPS:
-                make_rel(edges_dict, subject_curie, object_curie, edge_label, pmid, pub_date, sentence,
+            if subject_curie != object_curie or relation_label.lower() not in EDGE_LABELS_EXCLUDE_FOR_LOOPS:
+                make_rel(edges_dict, subject_curie, object_curie, relation_label, pmid, pub_date, sentence,
                          subject_score, object_score, negated)
 
         if predicate not in nodes_dict:

--- a/code/kg2/slim_kg2.py
+++ b/code/kg2/slim_kg2.py
@@ -27,7 +27,7 @@ def make_arg_parser():
 
 if __name__ == "__main__":
     node_set = set(["name", "id", "full_name", "category", "provided_by"])
-    edge_set = set(["simplified_relation", "subject", "object", "simplified_predicate", "provided_by"])
+    edge_set = set(["predicate", "subject", "object", "predicate_label", "provided_by"])
 
     args = make_arg_parser().parse_args()
     test_mode = args.test

--- a/code/kg2/validate_kg2_util_curies_urls_categories.py
+++ b/code/kg2/validate_kg2_util_curies_urls_categories.py
@@ -44,7 +44,7 @@ kg2_util.download_file_if_not_exist_locally(biolink_model_url, biolink_model_fil
 biolink_ont = kg2_util.make_ontology_from_local_file(biolink_model_file_name)
 biolink_categories_ontology_depths = kg2_util.get_biolink_categories_ontology_depths(biolink_ont)
 
-biolink_predicates = {url.replace(kg2_util.BASE_URL_BIOLINK_META, '') for url in
+biolink_edge_labels = {url.replace(kg2_util.BASE_URL_BIOLINK_META, '') for url in
                        biolink_ont.children(kg2_util.BASE_URL_BIOLINK_META + 'SlotDefinition')}
 
 for variable_name in dir(kg2_util):
@@ -69,5 +69,5 @@ for variable_name in dir(kg2_util):
         url = variable_value
         assert iri_shortener(url) is not None, url
     elif variable_name.startswith('EDGE_LABEL_BIOLINK_'):
-        predicate = variable_value
-        assert kg2_util.CURIE_PREFIX_BIOLINK + ':' + predicate in biolink_predicates
+        relation_label = variable_value
+        assert kg2_util.CURIE_PREFIX_BIOLINK + ':' + relation_label in biolink_edge_labels

--- a/code/kg2/validate_predicate_remap_yaml.py
+++ b/code/kg2/validate_predicate_remap_yaml.py
@@ -96,11 +96,11 @@ for relation, instruction_dict in pred_info.items():
             command = 'rename'
             subinfo = ['coexists_with', 'biolink:coexists_with']
     if subinfo is not None:
-        simplified_relation = subinfo[1]
-        if not simplified_relation.startswith('biolink:') and not simplified_relation.startswith('skos:closeMatch'):
-            if simplified_relation.startswith('FMA:') or \
-               simplified_relation.startswith('BSPO:') or \
-               simplified_relation.startswith('UBERON:'):
+        predicate = subinfo[1]
+        if not predicate.startswith('biolink:') and not predicate.startswith('skos:closeMatch'):
+            if predicate.startswith('FMA:') or \
+               predicate.startswith('BSPO:') or \
+               predicate.startswith('UBERON:'):
                 command = 'rename'
                 subinfo = ['coexists_with', 'biolink:coexists_with']
             else:


### PR DESCRIPTION
Edges with the changes in this PR (for KG2.5.0) now look like this, as discussed in #1173:
```
        {
            "negated": false,
            "object": "biolink:overlaps",
            "predicate": "biolink:subclass_of",
            "predicate_label": "subclass_of",
            "provided_by": [
                "biolink_download_source:biolink-model.owl.ttl"
            ],
            "publications": [],
            "publications_info": {},
            "relation": "rdfs:subPropertyOf",
            "relation_label": "sub_property_of",
            "subject": "biolink:has_part",
            "update_date": "Fri Dec  4 00:30:59 2020"
        },
```
 Tagging @amykglen so she is aware :)