### PR TITLE
Issue 1744 - Zombie Process accumulation issue

### DIFF
--- a/code/UI/OpenAPI/python-flask-server/KG2/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/KG2/openapi_server/__main__.py
@@ -24,6 +24,7 @@ def receive_sigchld(signal_number, frame):
                     break
             except ChildProcessError as e:
                 logging.error(repr(e))
+                break
 
 def receive_sigpipe(signal_number, frame):
     if signal_number == signal.SIGPIPE:

--- a/code/UI/OpenAPI/python-flask-server/KG2/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/KG2/openapi_server/__main__.py
@@ -23,7 +23,7 @@ def receive_sigchld(signal_number, frame):
                 if pid == 0:
                     break
             except ChildProcessError as e:
-                logging.error(repr(e))
+                logging.debug(repr(e) + "; this is expected if there are no more child processes to reap")
                 break
 
 def receive_sigpipe(signal_number, frame):

--- a/code/UI/OpenAPI/python-flask-server/KG2/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/KG2/openapi_server/__main__.py
@@ -4,16 +4,26 @@ import connexion, flask, flask_cors
 import logging
 import json
 import openapi_server.encoder
-import os, sys, signal
+import os, sys, signal, atexit
 
 logging.basicConfig(level=logging.INFO)  # can change this to logging.DEBUG for debuggging
 
+@atexit.register
+def ignore_sigchld():
+    logging.debug("Setting SIGCHLD to SIG_IGN before exiting")
+    signal.signal(signal.SIGCHLD, signal.SIG_IGN)
+
+
 def receive_sigchld(signal_number, frame):
     if signal_number == signal.SIGCHLD:
-        try:
-            os.waitpid(-1, os.WNOHANG)
-        except ChildProcessError as e:
-            logging.error(repr(e))
+        while True:
+            try:
+                pid, _ = os.waitpid(-1, os.WNOHANG)
+                logging.debug(f"PID returned from call to os.waitpid: {pid}")
+                if pid == 0:
+                    break
+            except ChildProcessError as e:
+                logging.error(repr(e))
 
 def receive_sigpipe(signal_number, frame):
     if signal_number == signal.SIGPIPE:

--- a/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
@@ -24,6 +24,7 @@ def receive_sigchld(signal_number, frame):
                     break
             except ChildProcessError as e:
                 logging.error(repr(e))
+                break
 
 def receive_sigpipe(signal_number, frame):
     if signal_number == signal.SIGPIPE:

--- a/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
@@ -10,14 +10,20 @@ logging.basicConfig(level=logging.INFO)  # can change this to logging.DEBUG for 
 
 @atexit.register
 def ignore_sigchld():
+    logging.debug("Setting SIGCHLD to SIG_IGN before exiting")
     signal.signal(signal.SIGCHLD, signal.SIG_IGN)
 
+    
 def receive_sigchld(signal_number, frame):
     if signal_number == signal.SIGCHLD:
-        try:
-            os.waitpid(-1, os.WNOHANG)
-        except ChildProcessError as e:
-            logging.error(repr(e))
+        while True:
+            try:
+                pid, _ = os.waitpid(-1, os.WNOHANG)
+                logging.debug(f"PID returned from call to os.waitpid: {pid}")
+                if pid == 0:
+                    break
+            except ChildProcessError as e:
+                logging.error(repr(e))
 
 def receive_sigpipe(signal_number, frame):
     if signal_number == signal.SIGPIPE:

--- a/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
@@ -4,9 +4,13 @@ import connexion, flask, flask_cors
 import logging
 import json
 import openapi_server.encoder
-import os, sys, signal
+import os, sys, signal, atexit
 
 logging.basicConfig(level=logging.INFO)  # can change this to logging.DEBUG for debuggging
+
+@atexit.register
+def ignore_sigchld():
+    signal.signal(signal.SIGCHLD, signal.SIG_IGN)
 
 def receive_sigchld(signal_number, frame):
     if signal_number == signal.SIGCHLD:

--- a/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
@@ -23,7 +23,7 @@ def receive_sigchld(signal_number, frame):
                 if pid == 0:
                     break
             except ChildProcessError as e:
-                logging.error(repr(e))
+                logging.debug(repr(e) + "; this is expected if there are no more child processes to reap")
                 break
 
 def receive_sigpipe(signal_number, frame):


### PR DESCRIPTION
This should fix the zombie process issue. Would be good to review the code changes.  Current theory is that the zombie processes were accumulating because the installed SIGCHLD handler would reap only one child process. So in cases where there are two child processes exiting at nearly the same time, my guess is the handler got called only once, resulting in a "leak" of a zombie child process. In any event, only way to be sure is to deploy to `arax.ncats.io` and see if the leak stops. I have tested this code on `arax-backup.rtx.ai` using the ARAX browser UI, the `test_ARAX_api.py` pytest script, and the `test_ARAX_api_failure_modes.py` pytest script, and things look good. No zombies:
```
rt@5d5ebba937d1:/mnt/data/orangeboard/kg2/RTX/code/ARAX/test_production_api$ ps axwf
  PID TTY      STAT   TIME COMMAND
  257 pts/1    Ss     0:00 bash
  905 pts/1    S      0:00  \_ su - rt
  906 pts/1    S      0:00      \_ -su
  982 pts/1    R+     0:00          \_ ps axwf
    1 pts/0    Ss+    0:00 bash
  709 ?        Ss     0:00 /usr/sbin/apache2 -k start
  712 ?        Sl     0:00  \_ /usr/sbin/apache2 -k start
  713 ?        Sl     0:00  \_ /usr/sbin/apache2 -k start
  854 ?        S      0:28 python3 -u -m openapi_server
  887 ?        Sl     0:06 python3 -u -m openapi_server
  953 ?        R      2:03  \_ python3 -u -m openapi_server
```