### PR TITLE
Fixing test that tests SPOKE query to be better query with more results

### DIFF
--- a/code/ARAX/test/test_ARAX_expand.py
+++ b/code/ARAX/test/test_ARAX_expand.py
@@ -476,7 +476,7 @@ def test_molepro_query():
 def test_spoke_query():
     actions_list = [
         "add_qnode(ids=OMIM:603903, categories=biolink:PhenotypicFeature, key=n00)",
-        "add_qnode(categories=biolink:Gene, key=n01)",
+        "add_qnode(categories=biolink:PhenotypicFeature, key=n01)",
         "add_qedge(subject=n00, object=n01, key=e00)",
         "expand(kp=SPOKE)",
         "return(message=true, store=false)"


### PR DESCRIPTION
Changed the query to be a phenotypic feature which interacts with sickle cell anemia rather than a gene that interacts with sickle cell anemia. For some reason spoke returned only one result for the latter case. The new test has many more results.