### PR TITLE
update pubmed URL template

### DIFF
--- a/code/UI/interactive/rtx.js
+++ b/code/UI/interactive/rtx.js
@@ -2814,7 +2814,7 @@ function display_attribute(tab, att, semmeddb) {
                     var a = document.createElement("a");
                     a.className = 'attvalue';
                     a.target = '_blank';
-                    a.href = "https://www.ncbi.nlm.nih.gov/pubmed/" + val.split(":")[1];
+                    a.href = "https://pubmed.ncbi.nlm.nih.gov/" + val.split(":")[1];
 		    a.title = 'View in PubMed';
                     a.innerHTML = val;
                     cell.appendChild(a);


### PR DESCRIPTION
Currently, ARAX gives me Pubmed URLs like this https://www.ncbi.nlm.nih.gov/pubmed/26205326, which currently return 431 errors for me.  I believe this PR will update to the canonical URL https://pubmed.ncbi.nlm.nih.gov/26205326/