### PR TITLE
Issue 2455 (and also 2519 fixed in passing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ code/ARAX/ARAXQuery/Infer/data/xCRG_data/*.npz
 
 code/UI/OpenAPI/python-flask-server/openapi_server/openapi/openapi.json
 code/UI/OpenAPI/specifications/export/KG2/*/openapi.json
+**/cache_refresh.pid

--- a/code/ARAX/ARAXQuery/ARAX_expander.py
+++ b/code/ARAX/ARAXQuery/ARAX_expander.py
@@ -147,7 +147,11 @@ class ARAXExpander:
             message.knowledge_graph = KnowledgeGraph(nodes=dict(), edges=dict())
         log = response
         # Fetch the list of all registered kps with compatible versions
-        kp_selector = KPSelector(log=log)
+        try:
+            kp_selector = KPSelector(log=log)
+        except ValueError as e:
+            response.error(str(e))
+            return response
 
         # Save the original QG, if it hasn't already been saved in ARAXQuery (happens for DSL queries..)
         if not hasattr(response, "original_query_graph"):

--- a/code/ARAX/ARAXQuery/ARAX_response.py
+++ b/code/ARAX/ARAXQuery/ARAX_response.py
@@ -36,8 +36,10 @@ class ARAXResponse:
         self.n_warnings = 0
         self.data = {}
         self.envelope = None
-
         self.query_plan = { 'qedge_keys': {}, 'counter': 0 }
+        self.wait_time = None  # this attribute is set by trapi_querier.py
+        self.http_error = None  # this attribute is set by trapi_querier.py
+        self.timed_out = None  # this attribute is set by trapi_querier.py
 
 
     #### Add a debugging message

--- a/code/ARAX/ARAXQuery/Expand/expand_utilities.py
+++ b/code/ARAX/ARAXQuery/Expand/expand_utilities.py
@@ -36,12 +36,16 @@ RTXConfig = RTXConfiguration()
 
 
 class QGOrganizedKnowledgeGraph:
-    def __init__(self, nodes: Dict[str, Dict[str, Node]] = None, edges: Dict[str, Dict[str, Edge]] = None):
+    def __init__(self,
+                 nodes: Dict[str, Dict[str, Node]] = None,
+                 edges: Dict[str, Dict[str, Edge]] = None,
+                 unbound_nodes: Dict[str, Node] = None):
         self.nodes_by_qg_id = nodes if nodes else dict()
         self.edges_by_qg_id = edges if edges else dict()
+        self.unbound_nodes = unbound_nodes if unbound_nodes else dict()
 
     def __str__(self):
-        return f"nodes_by_qg_id:\n{self.nodes_by_qg_id}\nedges_by_qg_id:\n{self.edges_by_qg_id}"
+        return f"nodes_by_qg_id:\n{self.nodes_by_qg_id}\nedges_by_qg_id:\n{self.edges_by_qg_id}\nunbound_nodes:\n{self.unbound_nodes}"
 
     def add_node(self, node_key: str, node: Node, qnode_key: str):
         if qnode_key not in self.nodes_by_qg_id:
@@ -201,7 +205,7 @@ def get_counts_by_qg_id(dict_kg: QGOrganizedKnowledgeGraph) -> Dict[str, int]:
 def get_printable_counts_by_qg_id(dict_kg: QGOrganizedKnowledgeGraph) -> str:
     counts_by_qg_id = get_counts_by_qg_id(dict_kg)
     counts_string = ", ".join([f"{qg_id}: {counts_by_qg_id[qg_id]}" for qg_id in sorted(counts_by_qg_id)])
-    return counts_string if counts_string else "no answers"
+    return (counts_string + f", Unbound: {len(dict_kg.unbound_nodes)}")  if counts_string else "no answers"
 
 
 def get_qg_without_kryptonite_portion(qg: QueryGraph) -> QueryGraph:

--- a/code/ARAX/ARAXQuery/Expand/kp_info_cacher.py
+++ b/code/ARAX/ARAXQuery/Expand/kp_info_cacher.py
@@ -8,7 +8,7 @@ import pathlib
 import pickle
 import sys
 from datetime import datetime, timedelta
-from typing import Set, Dict, Optional
+from typing import Optional
 
 import requests
 import requests_cache
@@ -151,7 +151,7 @@ class KPInfoCacher:
     # --------------------------------- METHODS FOR BUILDING META MAP ----------------------------------------------- #
     # --- Note: These methods can't go in KPSelector because it would create a circular dependency with this class -- #
 
-    def _build_meta_map(self, allowed_kps_dict: Dict[str, str]):
+    def _build_meta_map(self, allowed_kps_dict: dict[str, str]):
         # Start with whatever pre-existing meta map we might already have (can use this info in case an API fails)
         cache_file = pathlib.Path(self.smart_api_and_meta_map_cache )
         if cache_file.exists():
@@ -201,7 +201,7 @@ class KPInfoCacher:
 
     @staticmethod
     def _convert_meta_kg_to_meta_map(kp_meta_kg: dict) -> dict:
-        kp_meta_map = dict()
+        kp_meta_map: dict[str, dict[str, set[str]]] = dict()
         for meta_edge in kp_meta_kg["edges"]:
             subject_category = meta_edge["subject"]
             object_category = meta_edge["object"]

--- a/code/ARAX/ARAXQuery/Expand/kp_selector.py
+++ b/code/ARAX/ARAXQuery/Expand/kp_selector.py
@@ -26,6 +26,8 @@ class KPSelector:
         self.kg2_mode = kg2_mode
         self.kp_cacher = KPInfoCacher()
         self.meta_map, self.kp_urls, self.kps_excluded_by_version, self.kps_excluded_by_maturity = self._load_cached_kp_info()
+        if (not self.kg2_mode) and (self.kp_urls is None):
+            raise ValueError("KP info cache has not been filled and we are not in KG2 mode; cannot initialize KP selector")
         self.valid_kps = {"infores:rtx-kg2"} if self.kg2_mode else set(self.kp_urls.keys())
         self.bh = BiolinkHelper()
 

--- a/code/ARAX/ARAXQuery/Expand/kp_selector.py
+++ b/code/ARAX/ARAXQuery/Expand/kp_selector.py
@@ -2,7 +2,7 @@
 import os
 import pprint
 import sys
-from typing import Set, List, Optional
+from typing import Optional
 from collections import defaultdict
 from itertools import product
 
@@ -47,7 +47,7 @@ class KPSelector:
             return (meta_map, smart_api_info["allowed_kp_urls"], smart_api_info["kps_excluded_by_version"],
                     smart_api_info["kps_excluded_by_maturity"])
 
-    def get_kps_for_single_hop_qg(self, qg: QueryGraph) -> Optional[Set[str]]:
+    def get_kps_for_single_hop_qg(self, qg: QueryGraph) -> Optional[set[str]]:
         """
         This function returns the names of the KPs that say they can answer the given one-hop query graph (based on
         the categories/predicates the QG uses).
@@ -125,7 +125,7 @@ class KPSelector:
 
         return kp_accepts
 
-    def get_desirable_equivalent_curies(self, curies: List[str], categories: Optional[List[str]], kp: str) -> List[str]:
+    def get_desirable_equivalent_curies(self, curies: list[str], categories: Optional[list[str]], kp: str) -> list[str]:
         """
         For each input curie, this function returns an equivalent curie(s) that uses a prefix the KP supports.
         """
@@ -141,8 +141,8 @@ class KPSelector:
             supported_prefixes = self._get_supported_prefixes(eu.convert_to_list(categories), kp)
             self.log.debug(f"{kp}: Prefixes {kp} supports for categories {categories} (and descendants) are: "
                            f"{supported_prefixes}")
-            converted_curies = set()
-            unsupported_curies = set()
+            converted_curies: set[str] = set()
+            unsupported_curies: set[str] = set()
             synonyms_dict = eu.get_curie_synonyms_dict(curies)
             # Convert each input curie to a preferred, supported prefix
             for input_curie, equivalent_curies in synonyms_dict.items():
@@ -201,16 +201,16 @@ class KPSelector:
     def _get_uppercase_prefix(curie: str) -> str:
         return curie.split(":")[0].upper()
 
-    def _get_supported_prefixes(self, categories: List[str], kp: str) -> Set[str]:
+    def _get_supported_prefixes(self, categories: list[str], kp: str) -> set[str]:
         categories_with_descendants = self.bh.get_descendants(eu.convert_to_list(categories), include_mixins=False)
         supported_prefixes = {prefix.upper() for category in categories_with_descendants
                               for prefix in self.meta_map[kp]["prefixes"].get(category, set())}
         return supported_prefixes
 
     def _triple_is_in_meta_map(self, kp: str,
-                               subject_categories: Set[str],
-                               predicates: Set[str],
-                               object_categories: Set[str]) -> bool:
+                               subject_categories: set[str],
+                               predicates: set[str],
+                               object_categories: set[str]) -> bool:
         """
         Returns True if at least one possible triple exists in the KP's meta map. NOT meant to handle empty predicates;
         you should sub in "biolink:related_to" for QEdges without predicates before calling this method.
@@ -229,9 +229,7 @@ class KPSelector:
             if not subject_categories:  # any subject
                 subject_categories = set(predicates_map.keys())
             if not object_categories:  # any object
-                object_set = set()
-                _ = [object_set.add(obj) for obj_dict in predicates_map.values() for obj in obj_dict.keys()]
-                object_categories = object_set
+                object_categories = {obj for obj_dict in predicates_map.values() for obj in obj_dict.keys()}
 
             # handle combinations of subject and objects using cross product
             qg_sub_obj_dict = defaultdict(lambda: set())

--- a/code/ARAX/ARAXQuery/Infer/scripts/creativeCRG.py
+++ b/code/ARAX/ARAXQuery/Infer/scripts/creativeCRG.py
@@ -12,7 +12,6 @@ pathlist = os.getcwd().split(os.path.sep)
 RTXindex = pathlist.index("RTX")
 sys.path.append(os.path.sep.join([*pathlist[:(RTXindex + 1)], 'code', 'ARAX', 'ARAXQuery']))
 from ARAX_response import ARAXResponse
-from ARAX_query import ARAXQuery
 sys.path.append(os.path.sep.join([*pathlist[:(RTXindex + 1)], 'code', 'UI', 'OpenAPI', 'python-flask-server']))
 import openapi_server
 sys.path.append(os.path.sep.join([*pathlist[:(RTXindex + 1)], 'code', 'ARAX', 'NodeSynonymizer']))

--- a/code/ARAX/NodeSynonymizer/node_synonymizer.py
+++ b/code/ARAX/NodeSynonymizer/node_synonymizer.py
@@ -19,7 +19,6 @@ sys.path.append(os.path.sep.join([*pathlist[:(RTXindex + 1)], 'code']))
 from RTXConfiguration import RTXConfiguration
 
 sys.path.append(os.path.sep.join([*pathlist[:(RTXindex + 1)], 'code', 'ARAX', 'ARAXQuery']))
-from ARAX_database_manager import ARAXDatabaseManager
 
 sys.path.append(os.path.sep.join([*pathlist[:(RTXindex + 1)], 'code', 'UI', 'OpenAPI', 'python-flask-server']))
 from openapi_server.models.knowledge_graph import KnowledgeGraph


### PR DESCRIPTION
Hi all, can someone please review this PR to fix issue 2455?  The patch is a bit complex. Basically this patch is attempting to fix the issue that Expand doesn't know how to deal with auxiliary graphs and unbound nodes in TRAPI response knowledge graphs from KPs like Automat. Full details are in the #2455 issue. I've tested on arax.ncats.io/beta using the example queries and using the MWE one-hop query graph provided in the issue. Also reran all the pytest tests for ARAX-expand. So far, so good. But I could use a second pair of eyes to review these diffs for sanity.