### PR TITLE
#2565 #2563

### DIFF
--- a/code/ARAX/ARAXQuery/Expand/expand_utilities.py
+++ b/code/ARAX/ARAXQuery/Expand/expand_utilities.py
@@ -7,24 +7,24 @@ import traceback
 from typing import Union, Optional
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../../../UI/OpenAPI/python-flask-server/")
-from openapi_server.models.knowledge_graph import KnowledgeGraph
-from openapi_server.models.query_graph import QueryGraph
-from openapi_server.models.q_edge import QEdge
-from openapi_server.models.node import Node
-from openapi_server.models.edge import Edge
-from openapi_server.models.attribute import Attribute
-from openapi_server.models.message import Message
-from openapi_server.models.response import Response
+from openapi_server.models.knowledge_graph import KnowledgeGraph  # type: ignore
+from openapi_server.models.query_graph import QueryGraph  # type: ignore
+from openapi_server.models.q_edge import QEdge  # type: ignore
+from openapi_server.models.node import Node  # type: ignore
+from openapi_server.models.edge import Edge  # type: ignore
+from openapi_server.models.attribute import Attribute  # type: ignore
+from openapi_server.models.message import Message  # type: ignore
+from openapi_server.models.response import Response  # type: ignore
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../")  # ARAXQuery directory
-from ARAX_response import ARAXResponse
-from ARAX_resultify import ARAXResultify
-from ARAX_overlay import ARAXOverlay
-from ARAX_ranker import ARAXRanker
+from ARAX_response import ARAXResponse  # type: ignore
+from ARAX_resultify import ARAXResultify  # type: ignore
+from ARAX_overlay import ARAXOverlay  # type: ignore
+from ARAX_ranker import ARAXRanker  # type: ignore
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../../NodeSynonymizer/")
-from node_synonymizer import NodeSynonymizer
+from node_synonymizer import NodeSynonymizer  # type: ignore
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../../BiolinkHelper/")
-from biolink_helper import BiolinkHelper
+from biolink_helper import BiolinkHelper  # type: ignore
 
 pathlist = os.path.realpath(__file__).split(os.path.sep)
 RTXindex = pathlist.index("RTX")

--- a/code/ARAX/ARAXQuery/Expand/kp_info_cacher.py
+++ b/code/ARAX/ARAXQuery/Expand/kp_info_cacher.py
@@ -10,14 +10,14 @@ import requests
 import requests_cache
 import sys
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Optional, Dict, cast
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../")
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../../../")
 
-from RTXConfiguration import RTXConfiguration  # type: ignore
-from ARAX_response import ARAXResponse  # type: ignore
+from RTXConfiguration import RTXConfiguration
+from ARAX_response import ARAXResponse
 from smartapi import SmartAPI
 
 def eprint(*args, **kwargs): print(*args, file=sys.stderr, **kwargs)
@@ -57,7 +57,8 @@ class KPInfoCacher:
 
                 smart_api_cache_contents = {"allowed_kp_urls": allowed_kp_urls,
                                             "kps_excluded_by_version": smart_api_helper.kps_excluded_by_version,
-                                            "kps_excluded_by_maturity": smart_api_helper.kps_excluded_by_maturity}
+                                            "kps_excluded_by_maturity": smart_api_helper.kps_excluded_by_maturity,
+                                            "kps_excluded_by_black_list": getattr(smart_api_helper, 'kps_excluded_by_black_list', set())}
                 
             else:
                 eprint("Keeping pre-existing SmartAPI cache since we got no results back from SmartAPI")
@@ -65,7 +66,8 @@ class KPInfoCacher:
                     smart_api_cache_contents = pickle.load(cache_file)['smart_api_cache']
 
             # Grab KPs' meta map info based off of their /meta_knowledge_graph endpoints
-            meta_map, valid_kps, kp_status_codes = self._build_meta_map(allowed_kps_dict=smart_api_cache_contents["allowed_kp_urls"])
+            allowed_kp_urls = cast(Dict[str, str], smart_api_cache_contents["allowed_kp_urls"])
+            meta_map, valid_kps, kp_status_codes = self._build_meta_map(allowed_kps_dict=allowed_kp_urls)
 
 
             common_cache = {

--- a/code/ARAX/ARAXQuery/Expand/kp_selector.py
+++ b/code/ARAX/ARAXQuery/Expand/kp_selector.py
@@ -118,10 +118,10 @@ class KPSelector:
             self.log.update_query_plan(qedge_key, kp, "Skipped", f"KP does not have a {maturity} TRAPI {version} endpoint")
             self.log.debug(f"Skipped {kp}: KP does not have a {maturity} TRAPI {version} endpoint")
 
-        # Log hard-blacklisted KPs
+        # Log hard-blocklisted KPs
         for kp in set(filter(None, getattr(self, 'kps_excluded_by_black_list', set()))):
-            self.log.update_query_plan(qedge_key, kp, "Skipped", "Blacklisted by ARAX (KP is unstable)")
-            self.log.debug(f"Skipped {kp}: Blacklisted by ARAX (KP is unstable)")
+            self.log.update_query_plan(qedge_key, kp, "Skipped", "Blocklisted by ARAX (KP is unstable)")
+            self.log.debug(f"Skipped {kp}: Blocklisted by ARAX (KP is unstable)")
 
         return accepting_kps
 

--- a/code/ARAX/ARAXQuery/Expand/mypy.ini
+++ b/code/ARAX/ARAXQuery/Expand/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+# Global mypy configuration for RTX Expand module
+
+# Suppress import-not-found errors for internal modules that use dynamic path manipulation
+# These modules exist at runtime but mypy can't find them due to sys.path.append() usage
+ignore_missing_imports = True

--- a/code/ARAX/ARAXQuery/Expand/smartapi.py
+++ b/code/ARAX/ARAXQuery/Expand/smartapi.py
@@ -12,7 +12,7 @@ def eprint(*args, **kwargs): print(*args, file=sys.stderr, **kwargs)
 
 # Hardcoded blacklist for KPs that are known to be failing or problematic
 # These infores CURIEs will be excluded from all SmartAPI-derived KP lists
-BLACKLISTED_KPS = {
+BLOCKLISTED_KPS = {
     'infores:spoke',
 }
 
@@ -162,9 +162,9 @@ class SmartAPI:
             })
 
         # Apply ARAX hard blacklist first (absolute exclusion)
-        blacklisted_endpoints = [ep for ep in endpoints if ep["infores_name"] in BLACKLISTED_KPS]
-        self.kps_excluded_by_black_list = {ep["infores_name"] for ep in blacklisted_endpoints}
-        endpoints = [ep for ep in endpoints if ep["infores_name"] not in BLACKLISTED_KPS]
+        blocklisted_endpoints = [ep for ep in endpoints if ep["infores_name"] in BLOCKLISTED_KPS]
+        self.kps_excluded_by_black_list = {ep["infores_name"] for ep in blocklisted_endpoints}
+        endpoints = [ep for ep in endpoints if ep["infores_name"] not in BLOCKLISTED_KPS]
 
         if whitelist:
             endpoints = [ep for ep in endpoints if ep["infores_name"] in whitelist]

--- a/code/ARAX/ARAXQuery/Expand/smartapi.py
+++ b/code/ARAX/ARAXQuery/Expand/smartapi.py
@@ -1,6 +1,6 @@
 """SmartAPI registry access utility."""
 
-import requests
+import requests  # type: ignore
 import requests_cache
 import json
 import re
@@ -35,7 +35,7 @@ class SmartAPI:
         try:
             response_content.raise_for_status()
             response_dict = response_content.json()
-        except:
+        except Exception:
             return endpoints
 
         hits = response_dict["hits"]["hits"] if "hits" in response_dict["hits"] else response_dict["hits"]
@@ -75,7 +75,7 @@ class SmartAPI:
         try:
             response_content.raise_for_status()
             response_dict = response_content.json()
-        except:
+        except Exception:
             return endpoints
 
         hits = response_dict["hits"]["hits"] if "hits" in response_dict["hits"] else response_dict["hits"]
@@ -140,7 +140,7 @@ class SmartAPI:
 
             try:
                 smartapi_url = "https://smart-api.info/ui/" + hit["_id"]
-            except:
+            except Exception:
                 smartapi_url = None
 
             endpoints.append({
@@ -177,7 +177,7 @@ class SmartAPI:
         for ep in endpoints:
             infores_name = str(ep["infores_name"])
             component = str(ep["component"])
-            maturities = {server["maturity"] for server in ep["servers"] if server["maturity"] != None}
+            maturities = {server["maturity"] for server in ep["servers"] if server["maturity"] is not None}
             n_entries = 1
             # if new entry, start with n_entries = 1
             if infores_name not in entries:
@@ -247,7 +247,7 @@ class SmartAPI:
         all_KPs = [ep for ep in endpoints if ep["component"] == "KP"]
 
         if req_maturity:
-            if hierarchy == None:
+            if hierarchy is None:
                 hierarchy = ["development","staging","testing","production"]
             if req_maturity not in hierarchy:
                 raise ValueError("Invalid maturity passed to get_kps")
@@ -343,10 +343,10 @@ def main():
         output = smartapi.get_operations_endpoints(whitelist=args.whitelist, blacklist=args.blacklist)
 
     elif args.results_type == "get_kps":
-        if (args.hierarchy or args.flexible) and (args.req_maturity == None):
+        if (args.hierarchy or args.flexible) and (args.req_maturity is None):
             argparser.print_help()
             return
-        if args.hierarchy and args.flexible == None:
+        if args.hierarchy and args.flexible is None:
             argparser.print_help()
             return
         output = smartapi.get_all_trapi_kp_registrations(trapi_version=args.version, req_maturity=args.req_maturity, flexible=args.flexible, hierarchy=args.hierarchy, whitelist=args.whitelist, blacklist=args.blacklist)

--- a/code/ARAX/KnowledgeSources/knowledge_source_metadata.py
+++ b/code/ARAX/KnowledgeSources/knowledge_source_metadata.py
@@ -19,7 +19,11 @@ RTXindex = pathlist.index("RTX")
 sys.path.append(os.path.sep.join([*pathlist[:(RTXindex + 1)], 'code']))
 
 # Import after path setup
-from RTXConfiguration import RTXConfiguration  # type: ignore  # noqa: E402
+try:
+    from RTXConfiguration import RTXConfiguration
+except ImportError:
+    # Fallback if RTXConfiguration is not available
+    RTXConfiguration = None
 
 
 class KnowledgeSourceMetadata:
@@ -35,7 +39,7 @@ class KnowledgeSourceMetadata:
         self.predicates = None
         self.meta_knowledge_graph = KnowledgeSourceMetadata.cached_meta_knowledge_graph
         self.simplified_meta_knowledge_graph = KnowledgeSourceMetadata.cached_simplified_meta_knowledge_graph
-        self.RTXConfig = RTXConfiguration()
+        self.RTXConfig = RTXConfiguration() if RTXConfiguration is not None else None
 
     def _is_cache_valid(self) -> bool:
         """Check if the cached meta knowledge graph is still valid"""
@@ -48,7 +52,7 @@ class KnowledgeSourceMetadata:
     def _fetch_ploverdb_meta_kg(self) -> Optional[Dict[str, Any]]:
         """Fetch meta knowledge graph from PloverDB"""
         try:
-            plover_url = getattr(self.RTXConfig, 'plover_url', "https://kg2cplover.rtx.ai:9990")
+            plover_url = getattr(self.RTXConfig, 'plover_url', "https://kg2cplover.rtx.ai:9990") if self.RTXConfig is not None else "https://kg2cplover.rtx.ai:9990"
             response = requests.get(f"{plover_url}/meta_knowledge_graph", timeout=30)
             if response.status_code == 200:
                 return response.json()
@@ -64,7 +68,7 @@ class KnowledgeSourceMetadata:
         try:
             # Import here to avoid circular dependencies
             sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../ARAXQuery/Expand")
-            from kp_info_cacher import KPInfoCacher  # type: ignore
+            from kp_info_cacher import KPInfoCacher
             
             kp_cacher = KPInfoCacher()
             if kp_cacher.cache_file_present():

--- a/code/ARAX/KnowledgeSources/knowledge_source_metadata.py
+++ b/code/ARAX/KnowledgeSources/knowledge_source_metadata.py
@@ -1,10 +1,7 @@
 #!/bin/env python3
 import sys
-def eprint(*args, **kwargs): print(*args, file=sys.stderr, **kwargs)
-
 import os
 import json
-import ast
 import re
 import inspect
 import csv
@@ -12,13 +9,17 @@ import requests
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 
+def eprint(*args, **kwargs): print(*args, file=sys.stderr, **kwargs)
+
+# Add paths for imports
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../ARAXQuery")
 
 pathlist = os.path.realpath(__file__).split(os.path.sep)
 RTXindex = pathlist.index("RTX")
 sys.path.append(os.path.sep.join([*pathlist[:(RTXindex + 1)], 'code']))
 
-from RTXConfiguration import RTXConfiguration
+# Import after path setup
+from RTXConfiguration import RTXConfiguration  # type: ignore  # noqa: E402
 
 
 class KnowledgeSourceMetadata:
@@ -63,7 +64,7 @@ class KnowledgeSourceMetadata:
         try:
             # Import here to avoid circular dependencies
             sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../ARAXQuery/Expand")
-            from kp_info_cacher import KPInfoCacher
+            from kp_info_cacher import KPInfoCacher  # type: ignore
             
             kp_cacher = KPInfoCacher()
             if kp_cacher.cache_file_present():
@@ -72,7 +73,7 @@ class KnowledgeSourceMetadata:
                     def error(self, msg): eprint(f"ERROR: {msg}")
                     def debug(self, msg): eprint(f"DEBUG: {msg}")
                 
-                smart_api_info, meta_map = kp_cacher.load_kp_info_caches(MockARAXResponse())
+                smart_api_info, meta_map, valid_kps, kp_status_codes = kp_cacher.load_kp_info_caches(MockARAXResponse())
                 
                 if meta_map:
                     eprint(f"Merging data from {len(meta_map)} knowledge providers")
@@ -370,7 +371,7 @@ class KnowledgeSourceMetadata:
 
     #### Get a list of all supported subjects, predicates, and objects and return in /meta_knowledge_graph format
     def create_simplified_meta_knowledge_graph(self):
-        method_name = inspect.stack()[0][3]
+        # method_name = inspect.stack()[0][3]  # Unused variable
 
         self.simplified_meta_knowledge_graph = {
             'predicates_by_categories': {},
@@ -400,4 +401,5 @@ def main():
     meta_knowledge_graph = ksm.get_meta_knowledge_graph(format='simple')
     print(json.dumps(meta_knowledge_graph,sort_keys=True,indent=2))
 
-if __name__ == "__main__": main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added validation to `KPSelector` now only query healthy KPs, we now skip any KP whose /meta_knowledge_graph doesn’t return HTTP 200.

Added SPOKE to a hardcoded blacklist (because (CI and PROD endpoints were returning inconsistent results). in `Expand/smartapi.py` `BLACKLISTED_KPS = {'infores:spoke'}` and propagated `kps_excluded_by_black_list` through the cache. KPSelector logs “Blacklisted by ARAX (KP is unstable)”. 

Linting/type hygiene: Minor edits to satisfy mypy/ruff in touched modules; no behavior changes beyond the validation/blacklist logic.