### PR TITLE
#2631 use computational_model in the agent_type for all ARA-generated…

### DIFF
--- a/code/ARAX/ARAXQuery/ARAX_expander.py
+++ b/code/ARAX/ARAXQuery/ARAX_expander.py
@@ -548,7 +548,7 @@ class ARAXExpander:
                                                sources=[RetrievalSource(resource_id="infores:arax",
                                                                         resource_role="primary_knowledge_source")],
                                                attributes=[Attribute(attribute_type_id="biolink:agent_type",
-                                                                     value="automated_agent",
+                                                                     value="computational_model",
                                                                      attribute_source="infores:arax"),
                                                            Attribute(attribute_type_id="biolink:knowledge_level",
                                                                      value="prediction",


### PR DESCRIPTION
Hi @dkoslicki,

This PR is created to fix issue #2631. I have tested it and now only the NGD scores still use `automated_agent`.