### PR TITLE
#2663 Updated confest.py default pytest now skips databases download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # cache files
 **/.web_cache
+code/ARAX/ARAXQuery/Expand/trapi_query_cacher_responses/*
 
 # config.json
 **/config.json

--- a/code/ARAX/test/conftest.py
+++ b/code/ARAX/test/conftest.py
@@ -25,7 +25,10 @@ def pytest_addoption(parser):
         "--runonlyexternal", action="store_true", default=False, help="run only external tests"
     )
     parser.addoption(
-        "--nodatabases", action="store_true", default=False, help="do not download databases"
+        "--nodatabases", action="store_true", default=False, help="(deprecated, now the default) do not download databases"
+    )
+    parser.addoption(
+        "--withdatabases", action="store_true", default=False, help="download/update databases before running tests"
     )
 
 def pytest_configure(config):
@@ -39,13 +42,12 @@ def pytest_sessionstart(session):
     """
 
     config = session.config
-    if not config.getoption("--nodatabases"):
-    # Ensure local databases are up to date
-        print(f"Running database manager to check for missing databases..")
+    if config.getoption("--withdatabases"):
+        print("Running database manager to check for missing databases..")
         db_manager = ARAXDatabaseManager(allow_downloads=True)
         db_manager.update_databases()
     else:
-        print("not checking ARAX databases")
+        print("Skipping database check (pass --withdatabases to download/update databases)")
 
     # Refresh KP info cache if it hasn't been updated in more than an hour
     kp_info_cacher = KPInfoCacher()


### PR DESCRIPTION
Thank you @saramsey for bringing this up

(old behavior):
Running pytest would automatically download/update ~200 GiB of databases
You had to remember to pass `--nodatabases` every time to skip it

(new behavior):
Running pytest skips the database download by default
You pass `--withdatabases` explicitly when you actually need them downloaded