### PR TITLE
Reduced Pathfinder unconstrained query using DSL with max_path_length 2.

### DIFF
--- a/code/ARAX/test/test_ARAX_connect.py
+++ b/code/ARAX/test/test_ARAX_connect.py
@@ -149,32 +149,15 @@ def _virtual_tester(message: Message, edge_predicate: str, relation: str, attrib
 #     assert len(response.envelope.message.query_graph.nodes) == 2
 #     assert len(response.envelope.message.query_graph.paths) == 1
 
-@pytest.mark.slow
-def test_TRAPI_unconstrained_query():
-    query = {
-        "message": {
-            "query_graph": {
-                "nodes": {
-                    "n0": {
-                        "ids": ["CHEBI:37626"]
-                    },
-                    "n1": {
-                        "ids": ["MONDO:0005015"]
-                    }
-                },
-                "paths": {
-                    "p0": {
-                        "subject": "n0",
-                        "object": "n1"
-                    }
-                }
-            }
-        }
-    }
 
-    araxq = ARAXQuery()
-    araxq.query(query)
-    response = araxq.response
+def test_TRAPI_unconstrained_query():
+    query = {"operations": {"actions": [
+        "add_qnode(ids=CHEBI:31690, key=n0)",
+        "add_qnode(ids=MONDO:0004979, key=n1)",
+        "add_qpath(subject=n0, object=n1)",
+        "connect(action=connect_nodes, max_path_length=2)"
+    ]}}
+    [response, message] = _do_arax_query(query)
     assert response.status == 'OK'
     assert len(response.envelope.message.results) == 1
     assert len(response.envelope.message.results[0].node_bindings) == 2


### PR DESCRIPTION
Tested and Response Time is below 15 seconds.