### PR TITLE
Issue 2703: make fork_mode configurable through flask_config.json

### DIFF
--- a/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
@@ -117,14 +117,15 @@ def main():
     try:
         with config_file_path.open('r', encoding="utf-8") as infile:
             local_config = json.load(infile)
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         eprint(f"Error loading config file: {config_file_path}")
         local_config = {}
     tcp_port = local_config.get('port', FLASK_DEFAULT_TCP_PORT)
     check_databases = local_config.get('check_databases', True)
     run_background_tasker = local_config.get('run_background_tasker', True)
     force_disable_telemetry = local_config.get('force_disable_telemetry', False)
-    query_controller_fork_mode = local_config.get('query_controller_fork_mode', True)
+    query_fork_mode = local_config.get('query_fork_mode', True)
+    child_process_rlimit = local_config.get('child_process_rlimit', 34359738368)
 
     if check_databases:
         from ARAX_database_manager import ARAXDatabaseManager  # pylint: disable=import-outside-toplevel, import-error
@@ -137,7 +138,7 @@ def main():
                 dbmanager.update_databases()
             else:
                 eprint("Databases seem to be complete")
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             eprint(traceback.format_exc())
             raise
         del dbmanager
@@ -156,7 +157,7 @@ def main():
                 ARAXBackgroundTasker(parent_pid).run_tasks()
                 eprint("Background tasker child process ended unexpectedly")
                 os._exit(1)
-            except Exception:
+            except Exception:  # pylint: disable=broad-exception-caught
                 eprint("Error in ARAXBackgroundTasker.run_tasks()")
                 eprint(traceback.format_exc())
                 os._exit(1)
@@ -212,7 +213,8 @@ def main():
     app = connexion.App(__name__, specification_dir=str(specification_dir))
     app.app.json_provider_class = CustomJSONProvider
     app.app.json = app.app.json_provider_class(app.app)
-    app.app.config["QUERY_CONTROLLER_FORK_MODE"] = query_controller_fork_mode
+    app.app.config["QUERY_FORK_MODE"] = query_fork_mode
+    app.app.config["CHILD_PROCESS_RLIMIT"] = child_process_rlimit
     eprint(f"Using JSON provider: {type(app.app.json).__name__}")
     app.add_api('openapi.yaml',
                 arguments={'title': 'ARAX Translator Reasoner'},

--- a/code/UI/OpenAPI/python-flask-server/openapi_server/controllers/query_controller.py
+++ b/code/UI/OpenAPI/python-flask-server/openapi_server/controllers/query_controller.py
@@ -47,8 +47,6 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../../../../../AR
 import ARAX_query  # pylint: disable=import-outside-toplevel,import-error,wrong-import-position
 
 
-RLIMIT_CHILD_PROCESS_BYTES = 34359738368  # 32 GiB
-
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
@@ -60,7 +58,8 @@ def child_receive_sigpipe(signal_number, _):
 
 
 def run_query_dict_in_child_process(query_dict: dict,
-                                    query_runner: Callable) -> Iterator[str]:
+                                    query_runner: Callable,
+                                    child_rlimit: int | None = None) -> Iterator[str]:
     eprint("[query_controller]: Creating pipe and "
            "forking a child to handle the query")
     read_fd, write_fd = os.pipe()
@@ -81,9 +80,13 @@ def run_query_dict_in_child_process(query_dict: dict,
         os.close(read_fd)                   # child doesn't read from the pipe, it writes to it
         setproctitle.setproctitle("python3 query_controller::run_query_dict_in_child_process")
         # set a virtual memory limit for the child process
-        resource.setrlimit(
-            resource.RLIMIT_AS, (RLIMIT_CHILD_PROCESS_BYTES,
-                                 RLIMIT_CHILD_PROCESS_BYTES))
+        if child_rlimit is not None:
+            soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+            new_soft = min(child_rlimit, hard)
+            if sys.platform != "darwin":
+                resource.setrlimit(resource.RLIMIT_AS, (new_soft, hard))            
+            else:
+                print("skipping resetting RLIMIT_AS since we are running on macOS", file=sys.stderr)
         # get rid of signal handler so we don't double-print to the log on SIGPIPE error
         signal.signal(signal.SIGPIPE, child_receive_sigpipe)
         # disregard any SIGCHLD signal in the child process
@@ -136,7 +139,10 @@ def query(request_body: dict) -> tuple[flask.Response, int | None]:  # noqa: E50
     """
 
     app = flask.current_app
-    fork_mode = app.config.get("QUERY_CONTROLLER_FORK_MODE", True)
+    fork_mode = app.config.get("QUERY_FORK_MODE", True)
+    child_rlimit = None
+    if fork_mode:
+        child_rlimit = app.config.get("CHILD_PROCESS_RLIMIT", None)
 
     # Note that we never even get here if the request_body is not schema-valid JSON
 
@@ -157,20 +163,26 @@ def query(request_body: dict) -> tuple[flask.Response, int | None]:  # noqa: E50
         http_status = None
         if not fork_mode:
             json_generator = _run_query_and_return_json_generator_stream(
-                request_body)
+                request_body
+            )
         else:
             json_generator = run_query_dict_in_child_process(
                 request_body,
-                _run_query_and_return_json_generator_stream)
+                _run_query_and_return_json_generator_stream,
+                child_rlimit
+            )
         resp_obj = flask.Response(json_generator, mimetype="text/event-stream")
     else:
         if not fork_mode:
             json_generator = _run_query_and_return_json_generator_nonstream(
-                request_body)
+                request_body
+            )
         else:
             json_generator = run_query_dict_in_child_process(
                 request_body,
-                _run_query_and_return_json_generator_nonstream)
+                _run_query_and_return_json_generator_nonstream,
+                child_rlimit
+            )
         status_line = next(json_generator)
         status_dict = json.loads(status_line)
         http_status = status_dict['__http_status__']


### PR DESCRIPTION
This change will make it easier to test the Flask server on a local (as in, a laptop or under-the-desk) development machine, so each time, we don't have to edit `query_controller.py`.  We can just drop in our standard `flask_config.json` file for dev work.