### PR TITLE
Fix for issue 2736 (patch to trapi_querier.py)

### DIFF
--- a/code/ARAX/ARAXQuery/Expand/trapi_querier.py
+++ b/code/ARAX/ARAXQuery/Expand/trapi_querier.py
@@ -181,7 +181,7 @@ class TRAPIQuerier:
                 result_aux_graphs = {}
             add_bound_edges = {}
             delete_bound_edges = set()
-            kg_edges_for_qedge = result_kg.edges_by_qg_id[qedge_key]
+            kg_edges_for_qedge = result_kg.edges_by_qg_id.get(qedge_key, {})
             ## iterate over all the edges in the KG that are bound to the query
             ## graph edge whose key matches the variable `qedge_key`:
             for edge_id, edge in kg_edges_for_qedge.items():

--- a/code/ARAX/ARAXQuery/Expand/trapi_querier.py
+++ b/code/ARAX/ARAXQuery/Expand/trapi_querier.py
@@ -3,6 +3,7 @@ import json
 import sys
 import os
 import time
+import uuid
 from collections import defaultdict
 import math
 
@@ -20,6 +21,10 @@ from ARAX_response import ARAXResponse
 from ARAX_messenger import ARAXMessenger
 from trapi_query_cacher import KPQueryCacher
 import util
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../../BiolinkHelper/")
+from biolink_helper import get_biolink_helper
+
 def eprint(*args, **kwargs): print(*args, file=sys.stderr, **kwargs)
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../../UI/OpenAPI/python-flask-server/")
@@ -33,6 +38,14 @@ from openapi_server.models.attribute import Attribute  # noqa: E402
 from openapi_server.models.retrieval_source import RetrievalSource  # noqa: E402
 from openapi_server.models.auxiliary_graph import AuxiliaryGraph  # noqa: E402
 
+# All Biolink predicates considered "treats-like" (descendants of
+#  biolink:treats_or_applied_or_studied_to_treat); precomputed for O(1)
+#  membership tests.
+_TREATS_DESCENDANTS = frozenset(
+    get_biolink_helper().get_descendants("biolink:treats_or_applied_or_studied_to_treat")
+)
+
+UUID_NAMESPACE = uuid.UUID('31a17f10-c100-45ad-a3bb-2cccc37a8924')
 
 def _remove_attributes_with_invalid_values(response_json: dict,
                                            kp_curie: str,
@@ -86,7 +99,8 @@ class TRAPIQuerier:
                                                      upstream_resource_ids=[self.kp_infores_curie])
 
     async def answer_one_hop_query_async(
-            self, query_graph: QueryGraph,
+            self,
+            query_graph: QueryGraph,
             be_creative_treats: bool = False
     ) -> tuple[QGOrganizedKnowledgeGraph,
                dict[str, AuxiliaryGraph] | None]:
@@ -127,55 +141,97 @@ class TRAPIQuerier:
             log.update_query_plan(qedge_key, self.kp_infores_curie, "Skipped", skipped_message)
             return final_kg, None
 
-        # Treat this as a creative 'treats' query
+        # If the query graph has "knowledge_type: inferred" and this query edge
+        # has predicate 'biolink:treats', we want ARAX to be able to obtain from
+        # Retriever *lookup* type results using a broader set of predicates,
+        # which might include predicates such as
+        # `biolink:in_clinical_trials_for` or `biolink:applied_to_treat`, so
+        # that we can "predict" (not in the xDTD predication model, but rather,
+        # a heuristic ARAX-Expand prediction of a `biolink:treats` edge. To do
+        # this, we expand the set of predicates for this query edge to include
+        # the ancestral predicate
+        # `biolink:treats_or_applied_or_studied_to_treat`:
         if be_creative_treats:
-            for qedge in qg_copy.edges.values():  # Note there's only ever one qedge per QG here
-                qedge.predicates = list(set(qedge.predicates).union({"biolink:treats_or_applied_or_studied_to_treat",
-                                                                     "biolink:applied_to_treat"}))  # Just to be safe
-                log.info(f"For querying {self.kp_infores_curie}, edited {qedge_key} to use higher treats-type "
-                         f"predicates: {qedge.predicates}")
+            qedge = qg_copy.edges[qedge_key]
+            qedge.predicates = list(set(qedge.predicates).union(
+                {"biolink:treats_or_applied_or_studied_to_treat",
+                 "biolink:applied_to_treat"}))  # Just to be safe
+            log.info(f"For querying {self.kp_infores_curie}, "
+                     f"edited {qedge_key} to use higher treats-type "
+                     f"predicates: {qedge.predicates}")
 
         # Answer the query using the KP and load its answers into our object model
-        return await self._answer_query_using_kp_async(qg_copy)
+        result_kg, result_aux_graphs = await self._answer_query_using_kp_async(qg_copy)
 
-    def answer_one_hop_query(
-            self, query_graph: QueryGraph
-    ) -> tuple[QGOrganizedKnowledgeGraph,
-               dict[str, AuxiliaryGraph] | None]:
-        """
-        This function answers a one-hop (single-edge) query using the specified KP.
-        :param query_graph: A TRAPI query graph.
-        :return: An (almost) TRAPI knowledge graph containing all of the nodes and edges returned as
-                results for the query. (Organized by QG IDs.)
-        """
-        # TODO: Delete this method once we're ready to let go of the multiprocessing (vs. asyncio) option
-        log = self.log
-        final_kg = QGOrganizedKnowledgeGraph()
-        qg_copy = copy.deepcopy(query_graph)  # Create a copy so we don't modify the original
-        qedge_key = next(qedge_key for qedge_key in qg_copy.edges)
+        # If we are in `be_creative_treats` mode (see the long comment above),
+        # there might now be edges in the KG that are bound to this qedge, that
+        # do not have a predicate `biolink:treats`, but instead have some
+        # sibling predicate like `biolink:in_clinical_trials_for` or
+        # `biolink:applied_to_treat`, or an ancestral predicate like
+        # `biolink:treats_or_applied_or_studied_to_treat`. Per the ARAX team
+        # decision explained in ARAX issue 2736, for each such edge, we need to
+        # (1) move the edge to the "unbound edges" data structure in result_kg;
+        # (2) add a qedge-bound edge with the predicate `biolink:treats`; and
+        # (3) add an aux_graph that is referenced (as a "support graph") by the
+        # qedge-bound edge that we just added in item 2 (for information on what
+        # a support graph is, please see the Translator Reasoners Standard API
+        # at github.com/NCATSTranslator/ReasonerAPI):
+        if be_creative_treats:
+            if result_aux_graphs is None:
+                result_aux_graphs = {}
+            add_bound_edges = {}
+            delete_bound_edges = set()
+            kg_edges_for_qedge = result_kg.edges_by_qg_id[qedge_key]
+            ## iterate over all the edges in the KG that are bound to the query
+            ## graph edge whose key matches the variable `qedge_key`:
+            for edge_id, edge in kg_edges_for_qedge.items():
+                if edge.predicate != "biolink:treats" and \
+                   edge.predicate in _TREATS_DESCENDANTS:
+                    # if the edge came from xDTD, it should always have predicate
+                    # "biolink:treats"; so if we get here, we can safely assume
+                    # that this edge is a "lookup type" edge and not an xDTD edge
 
+                    # construct a UUID that is deterministically based on the subject/object
+                    # pair in the KG
+                    node_pair_uuid = uuid.uuid5(UUID_NAMESPACE, f"{edge.subject}-{edge.object}")
+                    heuristic_edge_id = f"ARAX-prediction-edge-{node_pair_uuid}"
 
-        self._verify_is_one_hop_query_graph(qg_copy)
-        if log.status != 'OK':
-            return final_kg, None
-
-        # Verify that the KP accepts these predicates/categories/prefixes
-        if self.kp_infores_curie != "infores:rtx-kg2":
-            if self.user_specified_kp:  # This is already done if expand chose the KP itself
-                if not self.kp_selector.kp_accepts_single_hop_qg(qg_copy, self.kp_infores_curie):
-                    log.error(f"{self.kp_infores_curie} cannot answer queries with the specified categories/predicates",
-                              error_code="UnsupportedQG")
-                    return final_kg, None
-
-        # Convert the QG so that it uses curies with prefixes the KP likes
-        qg_copy = self.kp_selector.make_qg_use_supported_prefixes(qg_copy, self.kp_infores_curie, log)
-        if not qg_copy:  # Means no equivalent curies with supported prefixes were found
-            skipped_message = "No equivalent curies with supported prefixes found"
-            log.update_query_plan(qedge_key, self.kp_infores_curie, "Skipped", skipped_message)
-            return final_kg, None
-
-        # Answer the query using the KP and load its answers into our object model
-        return self._answer_query_using_kp(qg_copy)
+                    edge_uuid = uuid.uuid5(UUID_NAMESPACE, edge_id)
+                    # no matter what, we are going to need to create an aux graph
+                    # for this edge (even if a heuristic predicted edge already exists):
+                    aux_graph_id = f"ARAX-prediction-auxgraph-{edge_uuid}"
+                    # have we already constructed a heuristic predicted edge for this pair?
+                    if heuristic_edge_id not in add_bound_edges:
+                        # no we have not, so make one
+                        heuristic_predicted_edge = Edge(predicate="biolink:treats",
+                                                        subject=edge.subject,
+                                                        object=edge.object,
+                                                        attributes=[],
+                                                        sources=[self.arax_retrieval_source])
+                        add_bound_edges[heuristic_edge_id] = heuristic_predicted_edge
+                    edge_attribute = Attribute(
+                        attribute_type_id = 'biolink:support_graphs',
+                        attribute_source = self.arax_infores_curie,
+                        value = [aux_graph_id]
+                    )
+                    add_bound_edges[heuristic_edge_id].attributes.append(edge_attribute)
+                    delete_bound_edges.add(edge_id)
+                    assert not edge_id.startswith('creative_DTD_prediction_')
+                    assert all(
+                        'creative_DTD_option_group' not in attribute.attribute_type_id
+                        for attribute in (getattr(edge, 'attributes', None) or [])
+                    )
+                    ## One has to specify an empty list for attributes in the initializer
+                    ## for AuxiliaryGraph, or one will get a ValueError later when the response
+                    ## gets serialized to JSON; I conjecture this represents a bug in the
+                    ## OpenAPI-generated model class, but anyhow, the workaround is easy here:
+                    aux_graph = AuxiliaryGraph(edges=[edge_id], attributes=[])
+                    result_aux_graphs[aux_graph_id] = aux_graph
+                    result_kg.unbound_edges[edge_id] = edge
+            for del_edge_id in delete_bound_edges:
+                del kg_edges_for_qedge[del_edge_id]
+            kg_edges_for_qedge.update(add_bound_edges)
+        return result_kg, result_aux_graphs
 
     def answer_single_node_query(
             self, single_node_qg: QueryGraph

--- a/code/ARAX/ARAXQuery/Expand/trapi_querier.py
+++ b/code/ARAX/ARAXQuery/Expand/trapi_querier.py
@@ -190,44 +190,71 @@ class TRAPIQuerier:
                     # if the edge came from xDTD, it should always have predicate
                     # "biolink:treats"; so if we get here, we can safely assume
                     # that this edge is a "lookup type" edge and not an xDTD edge
-
-                    # construct a UUID that is deterministically based on the subject/object
-                    # pair in the KG
-                    node_pair_uuid = uuid.uuid5(UUID_NAMESPACE, f"{edge.subject}-{edge.object}")
-                    heuristic_edge_id = f"ARAX-prediction-edge-{node_pair_uuid}"
-
-                    edge_uuid = uuid.uuid5(UUID_NAMESPACE, edge_id)
-                    # no matter what, we are going to need to create an aux graph
-                    # for this edge (even if a heuristic predicted edge already exists):
-                    aux_graph_id = f"ARAX-prediction-auxgraph-{edge_uuid}"
-                    # have we already constructed a heuristic predicted edge for this pair?
-                    if heuristic_edge_id not in add_bound_edges:
-                        # no we have not, so make one
-                        heuristic_predicted_edge = Edge(predicate="biolink:treats",
-                                                        subject=edge.subject,
-                                                        object=edge.object,
-                                                        attributes=[],
-                                                        sources=[self.arax_retrieval_source])
-                        add_bound_edges[heuristic_edge_id] = heuristic_predicted_edge
-                    edge_attribute = Attribute(
-                        attribute_type_id = 'biolink:support_graphs',
-                        attribute_source = self.arax_infores_curie,
-                        value = [aux_graph_id]
-                    )
-                    add_bound_edges[heuristic_edge_id].attributes.append(edge_attribute)
-                    delete_bound_edges.add(edge_id)
                     assert not edge_id.startswith('creative_DTD_prediction_')
                     assert all(
                         'creative_DTD_option_group' not in attribute.attribute_type_id
                         for attribute in (getattr(edge, 'attributes', None) or [])
                     )
-                    ## One has to specify an empty list for attributes in the initializer
-                    ## for AuxiliaryGraph, or one will get a ValueError later when the response
-                    ## gets serialized to JSON; I conjecture this represents a bug in the
-                    ## OpenAPI-generated model class, but anyhow, the workaround is easy here:
-                    aux_graph = AuxiliaryGraph(edges=[edge_id], attributes=[])
-                    result_aux_graphs[aux_graph_id] = aux_graph
+
+                    # General strategy for handling this case:
+                    # 1. Create an auxiliary graph and under the `edges` attribute
+                    #    of that auxiliary graph; add any bound edges for this qedge
+                    #    that do *not* have the "biolink:treats" predicate to the
+                    #    `.edges` attribute list on this auxiliary graph; add this
+                    #    auxiliary graph to the return auxiliary graphs object under
+                    #    a new UUID key
+                    # 2. Once for this qedge, make a new edge in the KG whose
+                    #    predicate is "biolink:treats" and whose subject and object
+                    #    nodes match those of `edge`; add a "support graph" attribute
+                    #    to that edge that references the aux graph created in step 1.
+
+                    # Construct a UUID that is deterministically based on the subject/object
+                    # pair in the KG:
+                    node_pair_uuid = uuid.uuid5(UUID_NAMESPACE, f"{edge.subject}-{edge.object}")
+
+                    # Make an edge ID for the heuristic prediction edge, based on
+                    # node_pair_uuid:
+                    heuristic_edge_id = f"ARAX-prediction-edge-{node_pair_uuid}"
+
+                    # Create an aux graph id based on the node pair:
+                    aux_graph_id = f"ARAX-prediction-auxgraph-{node_pair_uuid}"
+
+                    # Is there already an aux graph for this aux_graph_id? 
+                    if aux_graph_id not in result_aux_graphs:
+                        # => no, we have to make a new aux graph object and store it
+
+                        ## [One has to specify an empty list for attributes in
+                        ## the initializer for AuxiliaryGraph, or one will get a
+                        ## ValueError later when the response gets serialized to
+                        ## JSON; I conjecture this represents a bug in the
+                        ## OpenAPI-generated model class, but anyhow, the
+                        ## workaround is easy here:]
+                        aux_graph = AuxiliaryGraph(edges=[], attributes=[])
+                        result_aux_graphs[aux_graph_id] = aux_graph
+                    else:
+                        # => yes, so just get a reference to the stored aux graph
+                        aux_graph = result_aux_graphs[aux_graph_id]
+
+                    # Add the edge_id for this edge to the aux graph
+                    aux_graph.edges.append(edge_id)
+
+                    # Add the edge to the unbounded_edges object
                     result_kg.unbound_edges[edge_id] = edge
+                    # Have we already constructed a heuristic predicted edge for this pair?
+                    if heuristic_edge_id not in add_bound_edges:
+                        # no we have not, so make one
+                        edge_attribute = Attribute(
+                            attribute_type_id = 'biolink:support_graphs',
+                            attribute_source = self.arax_infores_curie,
+                            value = [aux_graph_id])
+                        heuristic_predicted_edge = Edge(predicate="biolink:treats",
+                                                        subject=edge.subject,
+                                                        object=edge.object,
+                                                        attributes=[edge_attribute],
+                                                        sources=[self.arax_retrieval_source])
+                        add_bound_edges[heuristic_edge_id] = heuristic_predicted_edge
+                    delete_bound_edges.add(edge_id)
+
             for del_edge_id in delete_bound_edges:
                 del kg_edges_for_qedge[del_edge_id]
             kg_edges_for_qedge.update(add_bound_edges)

--- a/code/ARAX/test/test_ARAX_expand.py
+++ b/code/ARAX/test/test_ARAX_expand.py
@@ -1,4 +1,3 @@
-#!/bin/env python3
 """
 Usage:
     Run all expand tests: pytest -v test_ARAX_expand.py
@@ -7,37 +6,31 @@ Usage:
 import json
 import os
 import sys
-from typing import List, Dict, Optional
 import pytest
-import yaml
+from typing import Any
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../ARAXQuery/")
 from ARAX_query import ARAXQuery
 from ARAX_response import ARAXResponse
-from ARAX_expander import ARAXExpander
-from ARAX_messenger import ARAXMessenger
-from ARAX_resultify import ARAXResultify
-from kp_info_cacher import KPInfoCacher
 import Expand.expand_utilities as eu
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../../UI/OpenAPI/python-flask-server/")
 from openapi_server.models.edge import Edge
 from openapi_server.models.node import Node
 from openapi_server.models.attribute import Attribute
-from openapi_server.models.query_graph import QueryGraph
 
-
-def _run_query_and_do_standard_testing(actions: Optional[List[str]] = None,
-                                       json_query: Optional[dict] = None,
+def _run_query_and_do_standard_testing(actions: list[str] | None = None,
+                                       json_query: dict | None  = None,
                                        kg_should_be_incomplete=False,
                                        debug=False,
                                        should_throw_error=False,
-                                       error_code: Optional[str] = None,
-                                       timeout: Optional[int] = None,
+                                       error_code: str | None = None,
+                                       timeout: int | None = None,
                                        return_message: bool = False) -> tuple:
     # Run the query
     araxq = ARAXQuery()
     assert actions or json_query  # Must provide some sort of query to run
-    query_object = {"operations": {"actions": actions}} if actions else {"message": {"query_graph": json_query}}
+    query_object: dict[str, Any] = \
+        {"operations": {"actions": actions}} if actions else {"message": {"query_graph": json_query}}
     if timeout:
         query_object["query_options"] = {"kp_timeout": timeout}
     response = araxq.query(query_object)
@@ -68,8 +61,8 @@ def _run_query_and_do_standard_testing(actions: Optional[List[str]] = None,
     return (nodes_by_qg_id, edges_by_qg_id, message) if return_message else (nodes_by_qg_id, edges_by_qg_id)
 
 
-def print_counts_by_qgid(nodes_by_qg_id: Dict[str, Dict[str, Node]], edges_by_qg_id: Dict[str, Dict[str, Edge]]):
-    print(f"KG counts:")
+def print_counts_by_qgid(nodes_by_qg_id: dict[str, dict[str, Node]], edges_by_qg_id: dict[str, dict[str, Edge]]):
+    print("KG counts:")
     if nodes_by_qg_id or edges_by_qg_id:
         for qnode_key, corresponding_nodes in sorted(nodes_by_qg_id.items()):
             print(f"  {qnode_key}: {len(corresponding_nodes)}")
@@ -79,20 +72,20 @@ def print_counts_by_qgid(nodes_by_qg_id: Dict[str, Dict[str, Node]], edges_by_qg
         print("  KG is empty")
 
 
-def print_nodes(nodes_by_qg_id: Dict[str, Dict[str, Node]]):
+def print_nodes(nodes_by_qg_id: dict[str, dict[str, Node]]):
     for qnode_key, nodes in sorted(nodes_by_qg_id.items()):
         for node_key, node in sorted(nodes.items()):
             print(f"{qnode_key}: {node.categories}, {node_key}, {node.name}, {node.qnode_keys}, "
                   f"{node.query_ids if hasattr(node, 'query_ids') else ''}")
 
 
-def print_edges(edges_by_qg_id: Dict[str, Dict[str, Edge]]):
+def print_edges(edges_by_qg_id: dict[str, dict[str, Edge]]):
     for qedge_key, edges in sorted(edges_by_qg_id.items()):
         for edge_key, edge in sorted(edges.items()):
             print(f"{qedge_key}: {edge_key}, {edge.subject}--{edge.predicate}->{edge.object}, {edge.qedge_keys}")
 
 
-def check_for_orphans(nodes_by_qg_id: Dict[str, Dict[str, Node]], edges_by_qg_id: Dict[str, Dict[str, Edge]]):
+def check_for_orphans(nodes_by_qg_id: dict[str, dict[str, Node]], edges_by_qg_id: dict[str, dict[str, Edge]]):
     node_keys = set()
     node_keys_used_by_edges = set()
     for qnode_key, nodes in nodes_by_qg_id.items():
@@ -105,7 +98,7 @@ def check_for_orphans(nodes_by_qg_id: Dict[str, Dict[str, Node]], edges_by_qg_id
     assert node_keys == node_keys_used_by_edges or len(node_keys_used_by_edges) == 0
 
 
-def check_property_format(nodes_by_qg_id: Dict[str, Dict[str, Node]], edges_by_qg_id: Dict[str, Dict[str, Edge]]):
+def check_property_format(nodes_by_qg_id: dict[str, dict[str, Node]], edges_by_qg_id: dict[str, dict[str, Edge]]):
     for qnode_key, nodes in nodes_by_qg_id.items():
         for node_key, node in nodes.items():
             assert node_key and isinstance(node_key, str)
@@ -142,7 +135,7 @@ def _check_attribute(attribute: Attribute):
 def get_primary_knowledge_source(edge: Edge) -> str:
     return next(source.resource_id for source in edge.sources if source.resource_role == "primary_knowledge_source")
 
-def get_support_graphs_attribute(edge: Edge) -> any:
+def get_support_graphs_attribute(edge: Edge) -> Any:
     sg_attrs = [attribute for attribute in edge.attributes if attribute.attribute_type_id == "biolink:support_graphs"]
     assert len(sg_attrs) <= 1
     return sg_attrs[0] if sg_attrs else None
@@ -235,7 +228,7 @@ def test_774_continue_if_no_results_query():
 
 def test_curie_list_query():
     actions_list = [
-        "add_qnode(ids=[MONDO:0008542, MONDO:0005027, MONDO:0005036], key=n00)",
+        "add_qnode(ids=[MONDO:0700217, MONDO:0005027, MONDO:0005036], key=n00)",
         "add_qnode(categories=biolink:PhenotypicFeature, key=n01)",
         "add_qedge(subject=n00, object=n01, predicates=biolink:has_phenotype, key=e00)",
         "expand(kp=infores:retriever)",
@@ -480,7 +473,7 @@ def test_exclude_edge_perpendicular():
     actions_list = [
         "add_qnode(ids=DOID:3312, key=n00)",
         "add_qnode(categories=biolink:Protein, key=n01, is_set=true)",
-        f"add_qnode(categories=biolink:ChemicalEntity, key=n02)",
+        "add_qnode(categories=biolink:ChemicalEntity, key=n02)",
         "add_qedge(subject=n01, object=n00, key=e00, predicates=biolink:causes)",
         "add_qedge(subject=n01, object=n02, key=e01, predicates=biolink:affects)",
         # 'Exclude' portion (just optional for now to get a baseline)
@@ -499,7 +492,7 @@ def test_exclude_edge_perpendicular():
     actions_list = [
         "add_qnode(ids=DOID:3312, key=n00)",
         "add_qnode(categories=biolink:Protein, key=n01, is_set=true)",
-        f"add_qnode(categories=biolink:ChemicalEntity, key=n02)",
+        "add_qnode(categories=biolink:ChemicalEntity, key=n02)",
         "add_qedge(subject=n01, object=n00, key=e00, predicates=biolink:causes)",
         "add_qedge(subject=n01, object=n02, key=e01, predicates=biolink:affects)",
         # 'Exclude' portion
@@ -1645,5 +1638,65 @@ def test_issue_2678():
     assert 'biolink:PhenotypicFeature' not in messages_str
 
 
+def test_issue_2736():
+    query_graph_dict = {
+        "edges": {
+            "q0": {
+                "attribute_constraints": [],
+                "knowledge_type": "inferred",
+                "object": "on",
+                "predicates": [
+                    "biolink:treats"
+                ],
+                "qualifier_constraints": [],
+                "subject": "sn"
+            }
+        },
+        "nodes": {
+            "on": {
+                "categories": [
+                    "biolink:Disease"
+                ],
+                "constraints": [],
+                "ids": [
+                    "MONDO:0016063"
+                ],
+                "is_set": False
+            },
+            "sn": {
+                "ids": [
+                    "CHEBI:9168"
+                ],
+                "categories": [
+                    "biolink:ChemicalEntity"
+                ],
+                "constraints": [],
+                "is_set": False
+            }
+        }
+    }
+    
+    envelope_dict = {
+        "message": {
+            "query_graph": query_graph_dict
+        }
+    }
+    aq = ARAXQuery()
+    response = aq.query_return_message(envelope_dict)
+    message = response.message
+    kg = message.knowledge_graph
+    results = message.results
+    edges = kg.edges
+    qedge_predicates = []
+    for result in results:
+        for analysis in result.analyses:
+            edge_bindings = analysis.edge_bindings['q0']
+            for edge_binding in edge_bindings:
+                edge_key = edge_binding.id
+                edge = edges[edge_key]
+                qedge_predicates.append(edge.predicate)
+    assert all(p == 'biolink:treats' for p in qedge_predicates)
+
+    
 if __name__ == "__main__":
     pytest.main(['-v', 'test_ARAX_expand.py'])

--- a/code/ARAX/test/test_ARAX_expand.py
+++ b/code/ARAX/test/test_ARAX_expand.py
@@ -228,8 +228,8 @@ def test_774_continue_if_no_results_query():
 
 def test_curie_list_query():
     actions_list = [
-        "add_qnode(ids=[MONDO:0700217, MONDO:0005027, MONDO:0005036], key=n00)",
-        "add_qnode(categories=biolink:PhenotypicFeature, key=n01)",
+        "add_qnode(ids=[MONDO:0008760, MONDO:0018755, MONDO:0010026], key=n00)",
+        "add_qnode(ids=[HP:0003074], key=n01)",
         "add_qedge(subject=n00, object=n01, predicates=biolink:has_phenotype, key=e00)",
         "expand(kp=infores:retriever)",
         "return(message=true, store=false)"

--- a/code/ARAX/test/test_ARAX_expand.py
+++ b/code/ARAX/test/test_ARAX_expand.py
@@ -135,7 +135,7 @@ def _check_attribute(attribute: Attribute):
 def get_primary_knowledge_source(edge: Edge) -> str:
     return next(source.resource_id for source in edge.sources if source.resource_role == "primary_knowledge_source")
 
-def get_support_graphs_attribute(edge: Edge) -> Any:
+def get_support_graphs_attribute(edge: Edge) -> Attribute | None:
     sg_attrs = [attribute for attribute in edge.attributes if attribute.attribute_type_id == "biolink:support_graphs"]
     assert len(sg_attrs) <= 1
     return sg_attrs[0] if sg_attrs else None

--- a/code/ARAX/test/test_ARAX_expand.py
+++ b/code/ARAX/test/test_ARAX_expand.py
@@ -19,7 +19,7 @@ from openapi_server.models.node import Node
 from openapi_server.models.attribute import Attribute
 
 def _run_query_and_do_standard_testing(actions: list[str] | None = None,
-                                       json_query: dict | None  = None,
+                                       json_query: dict | None = None,
                                        kg_should_be_incomplete=False,
                                        debug=False,
                                        should_throw_error=False,


### PR DESCRIPTION
This patch passes all standard pytests (including a new pytest written specifically to test for this issue, which was failing in the pre-patched code and is now passing in the patched code) and it looks good in the three standard ARAX example queries. Also ran the example query from the linked issue #2736 (which originally came from NCATSTranslator/Feedback issue 1182). The modules touched in this fix (`trapi_querier.py` and `test_ARAX_expand.py`) now pass ruff and mypy checks, and I reviewed the diffs with Claude and fixed all issues that it found.