### PR TITLE
#2746

### DIFF
--- a/code/ARAX/ARAXQuery/Expand/kp_info_cacher.py
+++ b/code/ARAX/ARAXQuery/Expand/kp_info_cacher.py
@@ -61,10 +61,6 @@ class KPInfoCacher:
                 # Transform the info into the format we want
                 allowed_kp_urls = {kp_registration["infores_name"]: self._get_kp_url_from_smartapi_registration(kp_registration)
                                    for kp_registration in smart_api_kp_registrations}
-                # Gandalf (Tier0) is not yet registered in SmartAPI, so inject it manually
-                # under its canonical infores. The URL comes from plover_url_override in
-                # config_dbs.json so it stays a single source of truth. See #2714.
-                allowed_kp_urls["infores:gandalf"] = self.rtx_config.plover_url
 
                 smart_api_cache_contents = {"allowed_kp_urls": allowed_kp_urls,
                                             "kps_excluded_by_version": smart_api_helper.kps_excluded_by_version,


### PR DESCRIPTION
This commit fixes a bug in which lookup-type single-hop query expansion by ARAX-expand would be done using both `infores:retriever` _and_ `infores:gandalf`, when it should be _just_ using Retriever. #2746 