### PR TITLE
Cherry picked commit from issue-2735 drop Launchpad/deadsnakes PPA, install Python 3.12 from Ubuntu 24.04 default repos

### DIFF
--- a/DockerBuild/CICD-Dockerfile
+++ b/DockerBuild/CICD-Dockerfile
@@ -44,8 +44,10 @@ RUN cd /var/www && /usr/sbin/apachectl configtest
 # install python 3.12 and packages
 RUN apt-get update
 RUN apt-get install -y python3 python3-pip
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:deadsnakes/ppa
+# Disabled to avoid Launchpad/deadsnakes network dependency in CI; Ubuntu 24.04
+# already includes Python 3.12 in the default repositories.
+# RUN apt-get install -y software-properties-common
+# RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get update && apt-get install -y python3.12 python3.12-dev python3.12-venv
 
 # make python3 be python 3.12 (used by RTX_OpenAPI.start and various scripts)

--- a/DockerBuild/Dockerfile
+++ b/DockerBuild/Dockerfile
@@ -65,8 +65,10 @@ RUN cd /var/www && /usr/sbin/apachectl configtest
 # install python 3.12 and packages
 RUN apt-get update
 RUN apt-get install -y python3 python3-pip
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:deadsnakes/ppa
+# Disabled for local AWS build reliability: this Launchpad-dependent PPA step times out
+# in some environments, and Ubuntu 24.04 already provides Python 3.12 in default repos.
+# RUN apt-get install -y software-properties-common
+# RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get update && apt-get install -y python3.12 python3.12-dev python3.12-venv
 
 # make python3 point to python3.12 (used by RTX_OpenAPI.start and various scripts)


### PR DESCRIPTION
Removes the Launchpad/deadsnakes PPA dependency from `DockerBuild/Dockerfile` and `DockerBuild/CICD-Dockerfile`. Ubuntu 24.04 already ships `python3.12` in its default `apt` repositories, so the `software-properties-common` + `add-apt-repository ppa:deadsnakes/ppa` step is unnecessary and has been intermittently timing out during AWS / CI builds.

This commit was originally landed on `issue-2735` as `226e7745d`, but `#2735` is in wait-state pending team discussion at the next ARAX AHM. Cherry-picking the Docker fix here so the Test Build can proceed in the meantime.