### PR TITLE
#2778 add all edge properties from KGX

### DIFF
--- a/code/ARAX/ARAXQuery/Infer/scripts/build_mapping_db.py
+++ b/code/ARAX/ARAXQuery/Infer/scripts/build_mapping_db.py
@@ -12,7 +12,7 @@ Tables:
   EDGE_MAPPING_TABLE:
     subject, predicate, object, id, category, qualifier, publications, sources,
     resource_id (pipe-delimited), resource_role (pipe-delimited), knowledge_level,
-    agent_type, stage_qualifier, original_subject, original_object
+    agent_type, stage_qualifier, original_subject, original_object, extra_attributes (JSON)
 
 Author: Chunyu Ma
 """
@@ -38,7 +38,7 @@ EdgeInfo = collections.namedtuple('EdgeInfo', [
     'subject', 'predicate', 'object', 'id', 'category', 'qualifier',
     'publications', 'sources', 'resource_id', 'resource_role',
     'knowledge_level', 'agent_type', 'stage_qualifier',
-    'original_subject', 'original_object'
+    'original_subject', 'original_object', 'extra_attributes'
 ])
 
 
@@ -298,7 +298,7 @@ class xDTDMappingDB:
         if predicate == 'SELF_LOOP_RELATION':
             return [EdgeInfo._make((
                 subject, predicate, object_id,
-                None, None, None, None, None, None, None, None, None, None, None, None
+                None, None, None, None, None, None, None, None, None, None, None, None, None
             ))]
 
         cursor.execute(

--- a/code/ARAX/ARAXQuery/Infer/scripts/infer_utilities.py
+++ b/code/ARAX/ARAXQuery/Infer/scripts/infer_utilities.py
@@ -543,9 +543,9 @@ class InferUtilities:
                         new_edge = Edge(subject=subject_curie, object=object_curie, predicate=predicate, attributes=[], sources=[])
                         edge_attribute_list = [
                             Attribute(original_attribute_name="defined_datetime", value=datetime.now().strftime("%Y-%m-%d %H:%M:%S"), attribute_type_id="metatype:Datetime"),
-                            Attribute(attribute_source=self.kp, attribute_type_id="biolink:agent_type", value=edge_info.agent_type),
-                            Attribute(attribute_source=self.kp, attribute_type_id="biolink:knowledge_level", value=edge_info.knowledge_level),
-                            Attribute(original_attribute_name=None, value=True, attribute_type_id="EDAM-DATA:1772", attribute_source=primary_knowledge_source, value_type_id="metatype:Boolean", value_url=None, description="This edge was extracted from Translator KG by ARAXInfer."),
+                            Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:agent_type", value=edge_info.agent_type),
+                            Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:knowledge_level", value=edge_info.knowledge_level),
+                            Attribute(original_attribute_name=None, value=True, attribute_source=primary_knowledge_source, value_type_id="metatype:Boolean", value_url=None, description="This edge was extracted from Translator KG by ARAXInfer."),
                         ]
                         if edge_info.publications:
                             pubs = edge_info.publications
@@ -553,8 +553,46 @@ class InferUtilities:
                                 pubs = json.loads(pubs)
                             if pubs:
                                 edge_attribute_list.append(
-                                    Attribute(attribute_source=self.kp, attribute_type_id="biolink:publications", original_attribute_name="publications", value=pubs)
+                                    Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:publications", original_attribute_name="publications", value=pubs)
                                 )
+                        if edge_info.category:
+                            cat = edge_info.category
+                            if isinstance(cat, str):
+                                try:
+                                    cat = json.loads(cat)
+                                except json.JSONDecodeError:
+                                    pass
+                            edge_attribute_list.append(
+                                Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:category", value=cat)
+                            )
+                        if edge_info.qualifier:
+                            edge_attribute_list.append(
+                                Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:qualifier", value=edge_info.qualifier)
+                            )
+                        if edge_info.stage_qualifier:
+                            edge_attribute_list.append(
+                                Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:stage_qualifier", value=edge_info.stage_qualifier)
+                            )
+                        if edge_info.original_subject:
+                            edge_attribute_list.append(
+                                Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:original_subject", value=edge_info.original_subject)
+                            )
+                        if edge_info.original_object:
+                            edge_attribute_list.append(
+                                Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:original_object", value=edge_info.original_object)
+                            )
+                        if edge_info.extra_attributes:
+                            extra = edge_info.extra_attributes
+                            if isinstance(extra, str):
+                                try:
+                                    extra = json.loads(extra)
+                                except json.JSONDecodeError:
+                                    extra = {}
+                            if isinstance(extra, dict):
+                                for attr_key, attr_val in extra.items():
+                                    edge_attribute_list.append(
+                                        Attribute(attribute_source=primary_knowledge_source, attribute_type_id=f"biolink:{attr_key}", value=attr_val)
+                                    )
                         retrieval_source = self._build_retrieval_sources(edge_info, kp=self.kp)
                         new_edge.attributes += edge_attribute_list
                         new_edge.sources += retrieval_source

--- a/code/ARAX/ARAXQuery/Infer/scripts/infer_utilities.py
+++ b/code/ARAX/ARAXQuery/Infer/scripts/infer_utilities.py
@@ -398,8 +398,7 @@ class InferUtilities:
                     # Add the edge to the knowledge graph
                     treat_score = node_id_to_score[canonical_id]
                     edge_attribute_list = [
-                        Attribute(original_attribute_name="defined_datetime", value=datetime.now().strftime("%Y-%m-%d %H:%M:%S"), attribute_type_id="metatype:Datetime"),
-                        Attribute(original_attribute_name=None, value=True, attribute_type_id="EDAM-DATA:1772", attribute_source=self.kp, value_type_id="metatype:Boolean", value_url=None, description="This edge is a container for a computed value between two nodes that is not directly attachable to other edges."),
+                        Attribute(original_attribute_name="created_datetime", value="2026-05-08", attribute_type_id="metatype:Datetime"),
                         Attribute(attribute_type_id="EDAM-DATA:0951", original_attribute_name="probability_treats", value=str(treat_score)),
                         Attribute(attribute_source=self.kp, attribute_type_id="biolink:agent_type", value="computational_model"),
                         Attribute(attribute_source=self.kp, attribute_type_id="biolink:knowledge_level", value="prediction"),
@@ -542,10 +541,9 @@ class InferUtilities:
                         primary_knowledge_source = self._get_primary_knowledge_source(edge_info)
                         new_edge = Edge(subject=subject_curie, object=object_curie, predicate=predicate, attributes=[], sources=[])
                         edge_attribute_list = [
-                            Attribute(original_attribute_name="defined_datetime", value=datetime.now().strftime("%Y-%m-%d %H:%M:%S"), attribute_type_id="metatype:Datetime"),
+                            Attribute(original_attribute_name="created_datetime", value="2026-05-08", attribute_type_id="metatype:Datetime"),
                             Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:agent_type", value=edge_info.agent_type),
                             Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:knowledge_level", value=edge_info.knowledge_level),
-                            Attribute(original_attribute_name=None, value=True, attribute_source=primary_knowledge_source, value_type_id="metatype:Boolean", value_url=None, description="This edge was extracted from Translator KG by ARAXInfer."),
                         ]
                         if edge_info.publications:
                             pubs = edge_info.publications
@@ -624,14 +622,13 @@ class InferUtilities:
                     essence_scores[path_drug_node_info.name] = treat_score
                 
                 edge_attribute_list = [
-                    Attribute(original_attribute_name="defined_datetime", value=datetime.now().strftime("%Y-%m-%d %H:%M:%S"), attribute_type_id="metatype:Datetime"),
-                    Attribute(original_attribute_name=None, value=True, attribute_type_id="EDAM-DATA:1772", attribute_source=self.kp, value_type_id="metatype:Boolean", value_url=None, description="This edge is a container for a computed value between two nodes that is not directly attachable to other edges."),
+                    Attribute(original_attribute_name="created_datetime", value="2026-05-08", attribute_type_id="metatype:Datetime"),
                     Attribute(attribute_type_id="EDAM-DATA:0951", original_attribute_name="probability_treats", value=str(treat_score)),
                     Attribute(attribute_source=self.kp, attribute_type_id="biolink:agent_type", value="computational_model"),
                     Attribute(attribute_source=self.kp, attribute_type_id="biolink:knowledge_level", value="prediction"),
                 ]
                 retrieval_source = [
-                        RetrievalSource(resource_id="infores:arax-xdtd", resource_role="primary_knowledge_source")
+                        RetrievalSource(resource_id=self.kp, resource_role="primary_knowledge_source")
                     ]
                 #edge_predicate = qedge_id
                 edge_predicate = "biolink:treats"

--- a/code/ARAX/ARAXQuery/result_transformer.py
+++ b/code/ARAX/ARAXQuery/result_transformer.py
@@ -143,9 +143,14 @@ class ResultTransformer:
                     group_id_prefix = "_".join(group_id.split("_")[:2])
 
                     # Create an attribute for the support graph that we'll tack onto the treats edge for this result
-                    support_graph_attribute = Attribute(attribute_type_id="biolink:support_graphs",
-                                                        value=[aux_graph_key],
-                                                        attribute_source="infores:arax")
+                    if group_id_prefix == "creative_DTD":
+                        support_graph_attribute = Attribute(attribute_type_id="biolink:support_graphs",
+                                                            value=[aux_graph_key],
+                                                            attribute_source="infores:arax-xdtd")
+                    else:
+                        support_graph_attribute = Attribute(attribute_type_id="biolink:support_graphs",
+                                                            value=[aux_graph_key],
+                                                            attribute_source="infores:arax")
                     # Find the 'treats' edge that this result is all about
                     inferred_qedge_keys = [qedge_key for qedge_key, qedge in response.original_query_graph.edges.items()
                                            if qedge.knowledge_type == "inferred"]

--- a/code/ARAX/test/test_ARAX_infer.py
+++ b/code/ARAX/test/test_ARAX_infer.py
@@ -584,3 +584,95 @@ def test_xdtd_publications_in_edge_attributes():
             break
 
     assert publications_found, "No biolink:publications attribute found on any explanation path edge"
+
+
+@pytest.mark.slow
+def test_xdtd_extra_edge_attributes():
+    query = {
+        "message": {"query_graph": {
+            "edges": {
+                "t_edge": {
+                    "attribute_constraints": [],
+                    "knowledge_type": "inferred",
+                    "object": "on",
+                    "predicates": [
+                        "biolink:treats"
+                    ],
+                    "qualifier_constraints": [],
+                    "subject": "sn"
+                }
+            },
+            "nodes": {
+                "on": {
+                    "categories": [
+                        "biolink:Disease"
+                    ],
+                    "constraints": [],
+                    "ids": [
+                        "MONDO:0015564"
+                    ],
+                },
+                "sn": {
+                    "categories": [
+                        "biolink:SmallMolecule"
+                    ],
+                    "constraints": [],
+                }
+            }
+        }}
+    }
+    [response, message] = _do_arax_query(query)
+    assert response.status == 'OK'
+    assert len(message.results) > 0
+
+    new_column_type_ids = {
+        "biolink:category",
+        "biolink:original_subject",
+        "biolink:original_object",
+    }
+
+    extra_attr_type_ids = {
+        "biolink:qualified_predicate",
+        "biolink:has_confidence_score",
+        "biolink:object_aspect_qualifier",
+        "biolink:object_direction_qualifier",
+        "biolink:has_affinity",
+        "biolink:species_context_qualifier",
+        "biolink:max_research_phase",
+        "biolink:p_value",
+        "biolink:has_supporting_studies",
+    }
+
+    found_new_column_attrs = set()
+    found_extra_attrs = set()
+    infer_edge_count = 0
+
+    for edge_key, edge in message.knowledge_graph.edges.items():
+        if not edge_key.startswith("urn:uuid:"):
+            continue
+        if not edge.attributes:
+            continue
+        infer_edge_count += 1
+
+        for attr in edge.attributes:
+            if attr.attribute_type_id in new_column_type_ids:
+                found_new_column_attrs.add(attr.attribute_type_id)
+                assert attr.value is not None
+                assert attr.original_attribute_name is None
+            if attr.attribute_type_id in extra_attr_type_ids:
+                found_extra_attrs.add(attr.attribute_type_id)
+                assert attr.value is not None
+                assert attr.original_attribute_name is None
+
+    assert infer_edge_count > 0, "No infer-produced path edges found"
+    assert found_new_column_attrs, (
+        "No new column attributes (category/original_subject/original_object) "
+        "found on any infer path edge"
+    )
+    assert "biolink:category" in found_new_column_attrs, (
+        "biolink:category attribute not found on any infer path edge"
+    )
+    assert found_extra_attrs, (
+        "No extra_attributes (qualified_predicate, has_confidence_score, etc.) "
+        "found on any infer path edge"
+    )


### PR DESCRIPTION
This PR is created to resolve the issue https://github.com/RTXteam/RTX/issues/2778 by doing the following:

1. Modified ARAX xDTD code to include ALL edge properties originally from Translator KG KGX to the xDTD MOA edge attributes.
2. Used the original source of the edge as attribute_source
3. Added a pytest for this change.