### PR TITLE
#2788: prevent rare condition between query_controller and meta_knowledge_graph_controller

### DIFF
--- a/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
@@ -64,7 +64,6 @@ from opentelemetry.exporter.jaeger.thrift import JaegerExporter
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.sdk.resources import Resource
 
-
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
@@ -111,6 +110,8 @@ def main():
 
     araxquery_dir = rtx_root_dir / "code/ARAX/ARAXQuery"
     add_to_syspath(araxquery_dir)
+
+    import Expand.kp_info_cacher  # noqa: F401   See ARAX issue 2788; avoid lazy-loading race condition
 
     config_file_path = HERE / "flask_config.json"
     # Read any local configuration details for this instance


### PR DESCRIPTION
It involves a race to lazily import `kp_info_cacher.py`.

See #2788 for the details.