### PR TITLE
Two import fixes for `kp_info_cacher`, found while looking at #2794

### DIFF
--- a/code/ARAX/ARAXQuery/ARAX_query.py
+++ b/code/ARAX/ARAXQuery/ARAX_query.py
@@ -20,6 +20,15 @@ from ARAX_ranker import ARAXRanker
 from operation_to_ARAXi import WorkflowToARAXi
 from ARAX_query_tracker import ARAXQueryTracker
 from result_transformer import ResultTransformer
+# Imported here instead of inside execute_processing_plan, which runs in
+# per-query threads. See ARAX issue 2794.
+from ARAX_expander import ARAXExpander
+from ARAX_overlay import ARAXOverlay
+from ARAX_filter_kg import ARAXFilterKG
+from ARAX_resultify import ARAXResultify
+from ARAX_filter_results import ARAXFilterResults
+from ARAX_infer import ARAXInfer
+from ARAX_connect import ARAXConnect
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../../UI/OpenAPI/python-flask-server/")
 from openapi_server.models.response import Response
@@ -673,14 +682,7 @@ class ARAXQuery:
             response.envelope.operations['actions'] = operations.actions
 
 
-            #### Import the individual ARAX processing modules and process DSL commands
-            from ARAX_expander import ARAXExpander
-            from ARAX_overlay import ARAXOverlay
-            from ARAX_filter_kg import ARAXFilterKG
-            from ARAX_resultify import ARAXResultify
-            from ARAX_filter_results import ARAXFilterResults
-            from ARAX_infer import ARAXInfer
-            from ARAX_connect import ARAXConnect
+            #### Instantiate the individual ARAX processing modules and process DSL commands
             expander = ARAXExpander()
             filter = ARAXFilter()
             overlay = ARAXOverlay()

--- a/code/ARAX/KnowledgeSources/knowledge_source_metadata.py
+++ b/code/ARAX/KnowledgeSources/knowledge_source_metadata.py
@@ -13,12 +13,16 @@ from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../ARAXQuery")
+sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../ARAXQuery/Expand")
 
 pathlist = os.path.realpath(__file__).split(os.path.sep)
 RTXindex = pathlist.index("RTX")
 sys.path.append(os.path.sep.join([*pathlist[:(RTXindex + 1)], 'code']))
 
 from RTXConfiguration import RTXConfiguration
+# kp_info_cacher lives in ARAXQuery/Expand, added to sys.path above.
+# Imported here instead of inside _merge_kp_info, see ARAX issue 2794.
+from kp_info_cacher import KPInfoCacher
 
 
 class KnowledgeSourceMetadata:
@@ -61,10 +65,6 @@ class KnowledgeSourceMetadata:
     def _merge_kp_info(self, base_meta_kg: Dict[str, Any]) -> Dict[str, Any]:
         """Merge additional KP information from the KP info cacher"""
         try:
-            # Import here to avoid circular dependencies
-            sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../ARAXQuery/Expand")
-            from kp_info_cacher import KPInfoCacher
-            
             kp_cacher = KPInfoCacher()
             if kp_cacher.cache_file_present():
                 # Create a simple mock ARAXResponse for logging

--- a/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
+++ b/code/UI/OpenAPI/python-flask-server/openapi_server/__main__.py
@@ -111,7 +111,13 @@ def main():
     araxquery_dir = rtx_root_dir / "code/ARAX/ARAXQuery"
     add_to_syspath(araxquery_dir)
 
-    import Expand.kp_info_cacher  # noqa: F401   See ARAX issue 2788; avoid lazy-loading race condition
+    # See ARAX issue 2788. Load kp_info_cacher once in the parent, before
+    # the fork below and before any request threads start, so two threads
+    # never import it for the first time at the same moment. Import the
+    # bare name, not Expand.kp_info_cacher, because that is the sys.modules
+    # key every runtime site uses and the one the race is on.
+    add_to_syspath(araxquery_dir / "Expand")
+    import kp_info_cacher  # noqa: F401  # pylint: disable=import-outside-toplevel, import-error, unused-import
 
     config_file_path = HERE / "flask_config.json"
     # Read any local configuration details for this instance


### PR DESCRIPTION
Two import fixes for `kp_info_cacher`, addressing #2794.

**`__main__.py`** corrects the #2788 race fix from #2790. That fix pre-imported `Expand.kp_info_cacher` (dotted), but every runtime site imports the bare `kp_info_cacher`, which is a separate `sys.modules` key, so the race stayed open. Now we load the bare name once in the parent before `os.fork()`, which makes all three sites cache hits.

**`knowledge_source_metadata.py`** moves the lazy `kp_info_cacher` import to the top of the file. There is no circular import (the old comment was wrong). It was inline only because the top of the file adds `../ARAXQuery` to `sys.path` but not `../ARAXQuery/Expand`, where `kp_info_cacher.py` lives.

Refs #2794, #2788, #2790.
