### PR TITLE
#2841 Add more general concept nodes to blocklist

### DIFF
--- a/code/ARAX/ARAXQuery/Filter_KG/remove_nodes.py
+++ b/code/ARAX/ARAXQuery/Filter_KG/remove_nodes.py
@@ -7,6 +7,11 @@ This module defines the `RemoveNodes` class, which provides methods to modify
 a Translator Reasoner API (TRAPI) `KnowledgeGraph` by removing nodes (and their
 associated edges) according to user-specified parameters or predefined rules.
 
+Terminology:
+- "General concepts" are nodes that have been determined to be generic, broad,
+  overly general, or non-informative. They are generally viewed as noisy or
+  not useful. Examples of these include "air", "surgery", "vitamins", etc.
+
 Supported removal strategies include:
 - Removing nodes by Biolink category (`remove_nodes_by_category`)
 - Removing nodes by property/value match (`remove_nodes_by_property`)
@@ -29,7 +34,7 @@ External dependencies:
 - Relies on ARAX message/response objects and TRAPI-compliant knowledge graph
   structures.
 - Loads a JSON "block list" file (`general_concepts.json`) from the ARAX
-  repository to identify overly general or non-informative nodes.
+  repository
 
 Implementation notes:
 - Uses defensive programming to handle heterogeneous node/edge structures
@@ -69,6 +74,8 @@ def eprint(*args, **kwargs):
 
 class RemoveNodes:
 
+    # The blocklist for nodes that are general concepts.
+    #
     # the first ARAX query loads the blocklist file, but ever after, just use the
     # blocklist data that has been cached as a class attribute `block_list_dict`
     block_list_dict: ClassVar[dict[str, Any] | None] = None

--- a/code/ARAX/KnowledgeSources/general_concepts.json
+++ b/code/ARAX/KnowledgeSources/general_concepts.json
@@ -4187,7 +4187,12 @@
         "KEGG.COMPOUND:C02737",
         "UMLS:C4740649",
         "UMLS:C0597298",
-        "UMLS:C0206587"
+        "UMLS:C0206587",
+        "CHEBI:36333",
+        "UMLS:C0242912",
+        "UMLS:C0599934",
+        "UMLS:C0302837",
+        "UMLS:C3166216"
     ],
     "synonyms": [
         "used in nicotine dependence",


### PR DESCRIPTION
* Add comments that help clarify some things
* Add (new) curies to the blocklist

Some additional thoughts:
- There are duplicate curies in `general_concepts.json` that ought to be culled; if we consider synonyms, there are probably even more
- That the blocklist is a JSON file means we cannot add comments (at least without hacks); these would be quite useful considering the opaque nature of curies