### PR TITLE
Translator feedback issue1350

### DIFF
--- a/code/ARAX/ARAXQuery/Infer/scripts/build_mapping_db.py
+++ b/code/ARAX/ARAXQuery/Infer/scripts/build_mapping_db.py
@@ -125,7 +125,8 @@ class xDTDMappingDB:
                 agent_type TEXT,
                 stage_qualifier TEXT,
                 original_subject TEXT,
-                original_object TEXT
+                original_object TEXT,
+                extra_attributes TEXT
             )
         """)
         self.conn.commit()
@@ -138,7 +139,7 @@ class xDTDMappingDB:
         """
         BATCH_SIZE = 50000
         NODE_INSERT = "INSERT INTO NODE_MAPPING_TABLE VALUES (?,?,?,?,?,?,?,?,?,?)"
-        EDGE_INSERT = "INSERT INTO EDGE_MAPPING_TABLE VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+        EDGE_INSERT = "INSERT INTO EDGE_MAPPING_TABLE VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
 
         self.conn.execute("PRAGMA journal_mode = WAL")
         self.conn.execute("PRAGMA synchronous = OFF")
@@ -180,11 +181,19 @@ class xDTDMappingDB:
             self.conn.commit()
         print(f"INFO: Inserted {count} rows into NODE_MAPPING_TABLE", flush=True)
 
+    _CORE_EDGE_KEYS = frozenset({
+        'subject', 'predicate', 'object', 'id', 'category', 'qualifier',
+        'publications', 'sources', 'knowledge_level', 'agent_type',
+        'stage_qualifier', 'original_subject', 'original_object',
+    })
+
     def _insert_edges(self, jsonl_path: str, insert_sql: str, batch_size: int):
         """Parse edges.jsonl and batch-insert rows.
 
         Flattens the 'sources' array into pipe-delimited resource_id and resource_role strings
-        for efficient querying of primary knowledge sources.
+        for efficient querying of primary knowledge sources.  Any top-level keys not in
+        _CORE_EDGE_KEYS are collected into an ``extra_attributes`` JSON column so that
+        qualifiers and other metadata survive the round-trip.
         """
         batch: list = []
         count = 0
@@ -194,6 +203,7 @@ class xDTDMappingDB:
                 sources = d.get('sources', [])
                 resource_ids = '|'.join(s.get('resource_id', '') for s in sources)
                 resource_roles = '|'.join(s.get('resource_role', '') for s in sources)
+                extra = {k: v for k, v in d.items() if k not in self._CORE_EDGE_KEYS}
                 row = (
                     d['subject'],
                     d['predicate'],
@@ -210,6 +220,7 @@ class xDTDMappingDB:
                     d.get('stage_qualifier'),
                     d.get('original_subject'),
                     d.get('original_object'),
+                    json.dumps(extra) if extra else None,
                 )
                 batch.append(row)
                 count += 1

--- a/code/ARAX/ARAXQuery/Infer/scripts/infer_utilities.py
+++ b/code/ARAX/ARAXQuery/Infer/scripts/infer_utilities.py
@@ -138,7 +138,8 @@ class InferUtilities:
             retrieval_sources.append(RetrievalSource(
                 resource_id=s['resource_id'],
                 resource_role=s['resource_role'],
-                upstream_resource_ids=s.get('upstream_resource_ids') or None
+                upstream_resource_ids=s.get('upstream_resource_ids') or None,
+                source_record_urls=s.get('source_record_urls') or None
             ))
 
         retrieval_sources.append(RetrievalSource(

--- a/code/ARAX/ARAXQuery/Infer/scripts/infer_utilities.py
+++ b/code/ARAX/ARAXQuery/Infer/scripts/infer_utilities.py
@@ -410,7 +410,7 @@ class InferUtilities:
                     # Add the edge to the knowledge graph
                     treat_score = node_id_to_score[canonical_id]
                     edge_attribute_list = [
-                        Attribute(original_attribute_name="created_datetime", value="2026-05-08", attribute_type_id="metatype:Datetime"),
+                        Attribute(original_attribute_name="created_datetime", value="2026-06-28", attribute_type_id="metatype:Datetime"),
                         Attribute(attribute_type_id="EDAM-DATA:0951", original_attribute_name="probability_treats", value=str(treat_score)),
                         Attribute(attribute_source=self.kp, attribute_type_id="biolink:agent_type", value="computational_model"),
                         Attribute(attribute_source=self.kp, attribute_type_id="biolink:knowledge_level", value="prediction"),
@@ -553,7 +553,7 @@ class InferUtilities:
                         primary_knowledge_source = self._get_primary_knowledge_source(edge_info)
                         new_edge = Edge(subject=subject_curie, object=object_curie, predicate=predicate, attributes=[], qualifiers=[], sources=[])
                         edge_attribute_list = [
-                            Attribute(original_attribute_name="created_datetime", value="2026-05-08", attribute_type_id="metatype:Datetime"),
+                            Attribute(original_attribute_name="created_datetime", value="2026-06-28", attribute_type_id="metatype:Datetime"),
                             Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:agent_type", value=edge_info.agent_type),
                             Attribute(attribute_source=primary_knowledge_source, attribute_type_id="biolink:knowledge_level", value=edge_info.knowledge_level),
                         ]
@@ -643,7 +643,7 @@ class InferUtilities:
                     essence_scores[path_drug_node_info.name] = treat_score
                 
                 edge_attribute_list = [
-                    Attribute(original_attribute_name="created_datetime", value="2026-05-08", attribute_type_id="metatype:Datetime"),
+                    Attribute(original_attribute_name="created_datetime", value="2026-06-28", attribute_type_id="metatype:Datetime"),
                     Attribute(attribute_type_id="EDAM-DATA:0951", original_attribute_name="probability_treats", value=str(treat_score)),
                     Attribute(attribute_source=self.kp, attribute_type_id="biolink:agent_type", value="computational_model"),
                     Attribute(attribute_source=self.kp, attribute_type_id="biolink:knowledge_level", value="prediction"),

--- a/code/ARAX/test/test_ARAX_infer.py
+++ b/code/ARAX/test/test_ARAX_infer.py
@@ -690,3 +690,65 @@ def test_xdtd_extra_edge_attributes_and_qualifiers():
         "No qualifiers (qualified_predicate, object_aspect_qualifier, etc.) "
         "found on any infer path edge"
     )
+
+
+@pytest.mark.slow
+def test_xdtd_source_record_urls_in_retrieval_sources():
+    query = {
+        "message": {"query_graph": {
+            "edges": {
+                "t_edge": {
+                    "attribute_constraints": [],
+                    "knowledge_type": "inferred",
+                    "object": "on",
+                    "predicates": [
+                        "biolink:treats"
+                    ],
+                    "qualifier_constraints": [],
+                    "subject": "sn"
+                }
+            },
+            "nodes": {
+                "on": {
+                    "categories": [
+                        "biolink:Disease"
+                    ],
+                    "constraints": [],
+                    "ids": [
+                        "MONDO:0015564"
+                    ],
+                },
+                "sn": {
+                    "categories": [
+                        "biolink:SmallMolecule"
+                    ],
+                    "constraints": [],
+                }
+            }
+        }}
+    }
+    [response, message] = _do_arax_query(query)
+    assert response.status == 'OK'
+    assert len(message.results) > 0
+
+    prediction_edge_keys = {k for k in message.knowledge_graph.edges if k.startswith("creative_DTD_prediction_")}
+    path_edge_keys = set(message.knowledge_graph.edges.keys()) - prediction_edge_keys
+
+    source_record_urls_found = False
+    for edge_key in path_edge_keys:
+        edge = message.knowledge_graph.edges[edge_key]
+        if not edge.sources:
+            continue
+        for source in edge.sources:
+            if source.source_record_urls:
+                source_record_urls_found = True
+                assert isinstance(source.source_record_urls, list)
+                assert len(source.source_record_urls) > 0
+                assert all(isinstance(url, str) for url in source.source_record_urls)
+                break
+        if source_record_urls_found:
+            break
+
+    assert source_record_urls_found, (
+        "No source_record_urls found in any RetrievalSource on explanation path edges"
+    )

--- a/code/ARAX/test/test_ARAX_infer.py
+++ b/code/ARAX/test/test_ARAX_infer.py
@@ -652,9 +652,11 @@ def test_xdtd_extra_edge_attributes_and_qualifiers():
     infer_edge_count = 0
 
     for edge_key, edge in message.knowledge_graph.edges.items():
-        if not edge_key.startswith("urn:uuid:"):
+        if edge_key.startswith("creative_DTD_prediction_"):
             continue
         if not edge.attributes:
+            continue
+        if not any(a.attribute_type_id == "metatype:Datetime" for a in edge.attributes):
             continue
         infer_edge_count += 1
 


### PR DESCRIPTION
This PR is created to fix the issue of missing the expected `source_record_urls` data in the MVP1 query (reported by https://github.com/NCATSTranslator/Feedback/issues/1353). Basically, it did the following main updates:

1. For `infer_utilities.py`, add code to recover the expected `source_record_urls` data from the xdtd database.
2. Add a test into `test_ARAX_infer.py` for confirming `source_record_urls` data is indeed recovered.