### PR TITLE
Automate test CI/CD deployment per-PR environments and cleanup

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,10 +1,12 @@
 # ARAX preview environments, one docker container per pull request on
 # cicd.rtx.ai. See deploy/preview/README.md and issue #2846.
 #
-# GitHub only ever runs the issue_comment and schedule triggers from the copy
-# of this file on the default branch. Until this workflow lands on master the
-# only trigger that works is workflow_dispatch, run against the issue-2846
-# branch with the pr_number input.
+# GitHub only registers a workflow, and only fires workflow_dispatch,
+# issue_comment and schedule, from the default branch copy of the file. Until
+# this workflow is merged to master no GitHub trigger works at all, not even
+# Run workflow, because the workflow does not appear in the Actions tab.
+# Test on the host with deploy/preview/deploy.sh until then, and verify the
+# triggers immediately after the merge.
 name: "Preview Deploy"
 
 on:
@@ -45,11 +47,18 @@ jobs:
     name: Deploy preview
     runs-on: [self-hosted, ARAX, docker]
     timeout-minutes: 120
+    # The command must be exactly /deploy, or /deploy followed by whitespace,
+    # so that comments like "/deploying soon" do not trigger a deploy. GitHub
+    # expressions have no regex, and a literal newline can only be produced
+    # with fromJSON.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
-       startsWith(github.event.comment.body, '/deploy') &&
+       (github.event.comment.body == '/deploy' ||
+        startsWith(github.event.comment.body, '/deploy ') ||
+        startsWith(github.event.comment.body, format('/deploy{0}', fromJSON('"\n"'))) ||
+        startsWith(github.event.comment.body, format('/deploy{0}', fromJSON('"\r"')))) &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
       - name: Resolve PR
@@ -274,11 +283,16 @@ jobs:
     name: Tear down preview
     runs-on: [self-hosted, ARAX, docker]
     timeout-minutes: 120
+    # Same exact-match rule as the deploy job: /undeploy alone or followed by
+    # whitespace, so "/undeployment" and similar do not tear a preview down.
     if: >-
       (github.event_name == 'pull_request' && github.event.action == 'closed') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
-       startsWith(github.event.comment.body, '/undeploy') &&
+       (github.event.comment.body == '/undeploy' ||
+        startsWith(github.event.comment.body, '/undeploy ') ||
+        startsWith(github.event.comment.body, format('/undeploy{0}', fromJSON('"\n"'))) ||
+        startsWith(github.event.comment.body, format('/undeploy{0}', fromJSON('"\r"')))) &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
       # On a pull_request event checkout would default to the PR merge ref,
@@ -291,15 +305,21 @@ jobs:
           fetch-depth: 1
 
       - name: Tear down preview
+        id: teardown
         env:
           PR: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: bash deploy/preview/teardown.sh "$PR"
 
+      # The comment reflects what actually happened. teardown.sh exits
+      # non-zero when a resource could not be removed, and silently claiming
+      # success here would leave leaked containers unnoticed.
       - name: Comment on PR
         if: always()
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          TEARDOWN_OUTCOME: ${{ steps.teardown.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
             const marker = '<!-- arax-preview-status -->';
@@ -308,7 +328,15 @@ jobs:
               core.info('no PR number available, nothing to comment on');
               return;
             }
-            const body = marker + '\n## ARAX preview\n\n🧹 ARAX preview for this PR was removed.';
+            const ok = process.env.TEARDOWN_OUTCOME === 'success';
+            const runUrl = process.env.RUN_URL;
+            const body = ok
+              ? marker + '\n## ARAX preview\n\n🧹 ARAX preview for this PR was removed.'
+              : marker + '\n## ARAX preview\n\n' +
+                '⚠️ Teardown did not finish cleanly. The container `rtx_pr_' + pr + '`, ' +
+                'the image `rtx:pr-' + pr + '` or its nginx route may still be live on the host. ' +
+                'See the [workflow run](' + runUrl + ') and clean up with ' +
+                '`bash deploy/preview/teardown.sh ' + pr + '` on cicd.rtx.ai.';
 
             const existing = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,355 @@
+# ARAX preview environments, one docker container per pull request on
+# cicd.rtx.ai. See deploy/preview/README.md and issue #2846.
+#
+# GitHub only ever runs the issue_comment and schedule triggers from the copy
+# of this file on the default branch. Until this workflow lands on master the
+# only trigger that works is workflow_dispatch, run against the issue-2846
+# branch with the pr_number input.
+name: "Preview Deploy"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to deploy"
+        required: true
+        type: string
+      run_tests:
+        description: "Run pytest inside the preview container after deploy"
+        required: false
+        type: boolean
+        default: false
+      pytest_args:
+        description: "Extra pytest args (for example -k test_ARAX_query)"
+        required: false
+        type: string
+        default: ""
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: "17 6 * * *"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: preview-${{ github.event.inputs.pr_number || github.event.issue.number || github.event.pull_request.number || 'gc' }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy preview
+    runs-on: [self-hosted, ARAX, docker]
+    timeout-minutes: 120
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/deploy') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    steps:
+      - name: Resolve PR
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fromInput = context.payload.inputs && context.payload.inputs.pr_number;
+            const fromComment = context.payload.issue && context.payload.issue.number;
+            const prNumber = parseInt(fromInput || fromComment, 10);
+
+            // Refusals are posted back to the PR when a comment triggered us,
+            // otherwise the person is already looking at the Actions log.
+            async function refuse(message) {
+              core.setFailed(message);
+              if (context.eventName === 'issue_comment' && prNumber) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: '❌ ARAX preview not deployed: ' + message,
+                });
+              }
+            }
+
+            if (!prNumber) {
+              await refuse('could not work out which pull request to deploy');
+              return;
+            }
+
+            const { data } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const upstream = context.repo.owner + '/' + context.repo.repo;
+            if (data.head.repo === null || data.head.repo.full_name !== upstream) {
+              await refuse('fork PRs are not supported (CICD-Dockerfile clones by branch name from RTXteam/RTX)');
+              return;
+            }
+            if (data.state !== 'open') {
+              await refuse('PR #' + prNumber + ' is ' + data.state + ', only open PRs can be deployed');
+              return;
+            }
+
+            core.setOutput('pr', String(prNumber));
+            core.setOutput('branch', data.head.ref);
+            core.setOutput('sha', data.head.sha);
+            core.setOutput('html_url', data.html_url);
+
+            // Acknowledge the /deploy comment so the author knows it was picked up.
+            if (context.eventName === 'issue_comment') {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes',
+              });
+            }
+
+      # Two checkouts on purpose. The scripts run from the trusted copy of this
+      # workflow's branch (the default branch for /deploy comments, the
+      # dispatched branch for Run workflow), so a PR opened before this tooling
+      # existed can still be previewed and a PR cannot swap the scripts that run
+      # on the self-hosted runner. The PR head goes into pr-head/ and is used
+      # only as the docker build context, which mirrors pytest.yml building the
+      # Dockerfile of the branch under test.
+      - name: Checkout the scripts
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Checkout the PR head as the build context
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve.outputs.sha }}
+          path: pr-head
+          fetch-depth: 1
+
+      - name: Deploy preview
+        id: deploy
+        env:
+          PR: ${{ steps.resolve.outputs.pr }}
+          BRANCH: ${{ steps.resolve.outputs.branch }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+          PREVIEW_BUILD_CONTEXT: ${{ github.workspace }}/pr-head/DockerBuild
+        run: |
+          set -o pipefail
+          bash deploy/preview/deploy.sh "$PR" "$BRANCH" "$SHA" 2>&1 | tee preview-deploy.log
+
+      - name: Smoke test
+        id: smoke
+        continue-on-error: true
+        env:
+          PR: ${{ steps.resolve.outputs.pr }}
+          RUN_TESTS: ${{ github.event.inputs.run_tests || 'false' }}
+          PYTEST_ARGS: ${{ github.event.inputs.pytest_args || '' }}
+        run: |
+          set -o pipefail
+          if [ "$RUN_TESTS" = "true" ]; then
+            bash deploy/preview/smoke.sh "$PR" --pytest "$PYTEST_ARGS" 2>&1 | tee preview-smoke.log
+          else
+            bash deploy/preview/smoke.sh "$PR" 2>&1 | tee preview-smoke.log
+          fi
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-pr-${{ steps.resolve.outputs.pr }}-logs
+          path: |
+            preview-deploy.log
+            preview-smoke.log
+          retention-days: 14
+          if-no-files-found: warn
+
+      # Values that originate outside this file (branch names above all) are
+      # handed to the script through env, never spliced into the JavaScript
+      # source with ${{ }}, so a crafted branch name cannot inject code.
+      - name: Comment on PR
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_TTL_DAYS: ${{ vars.PREVIEW_TTL_DAYS || '7' }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr }}
+          PR_BRANCH: ${{ steps.resolve.outputs.branch }}
+          PR_SHA: ${{ steps.resolve.outputs.sha }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- arax-preview-status -->';
+            const pr = Number(process.env.PR_NUMBER);
+            if (!pr) {
+              core.info('no PR was resolved, nothing to comment on');
+              return;
+            }
+
+            const deployOutcome = process.env.DEPLOY_OUTCOME;
+            const smokeOutcome = process.env.SMOKE_OUTCOME;
+            const ok = deployOutcome === 'success' && smokeOutcome === 'success';
+
+            let smokeTable = '_No smoke test output was produced._';
+            try {
+              const raw = fs.readFileSync('preview-smoke.log', 'utf8');
+              const start = raw.indexOf('| check |');
+              smokeTable = start >= 0 ? raw.slice(start).trim() : raw.trim();
+            } catch (error) {
+              core.info('preview-smoke.log is missing: ' + error.message);
+            }
+
+            const url = process.env.PREVIEW_URL || '';
+            const branch = process.env.PR_BRANCH || 'unknown';
+            const sha = process.env.PR_SHA || '';
+            const shortSha = sha ? sha.slice(0, 7) : 'unknown';
+            const runUrl = process.env.RUN_URL;
+            const ttl = process.env.PREVIEW_TTL_DAYS || '7';
+
+            const lines = [];
+            lines.push(marker);
+            lines.push('## ARAX preview');
+            lines.push('');
+            lines.push(ok ? '✅ deployed' : '❌ failed');
+            lines.push('');
+            if (url) {
+              lines.push('**URL:** ' + url);
+            } else {
+              lines.push('**URL:** not available, the deploy did not finish');
+            }
+            lines.push('');
+            lines.push('**Build:** `' + branch + '` @ `' + shortSha + '`');
+            lines.push('');
+            lines.push('### Smoke test');
+            lines.push('');
+            lines.push(smokeTable);
+            lines.push('');
+            lines.push('[Workflow run](' + runUrl + ')');
+            lines.push('');
+            lines.push('Comment `/deploy` to redeploy, `/undeploy` to remove. Previews are garbage-collected after ' + ttl + ' days or when the PR closes.');
+            const body = lines.join('\n');
+
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              per_page: 100,
+            });
+            const mine = existing.find(function (comment) {
+              return comment.body && comment.body.includes(marker);
+            });
+
+            if (mine) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: mine.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body: body,
+              });
+            }
+
+      # The smoke step is continue-on-error so that the comment above always
+      # runs. The job still has to go red when anything failed.
+      - name: Fail the job when deploy or smoke failed
+        if: steps.deploy.outcome == 'failure' || steps.smoke.outcome == 'failure'
+        run: |
+          echo "deploy outcome: ${{ steps.deploy.outcome }}"
+          echo "smoke outcome:  ${{ steps.smoke.outcome }}"
+          exit 1
+
+  teardown:
+    name: Tear down preview
+    runs-on: [self-hosted, ARAX, docker]
+    timeout-minutes: 120
+    if: >-
+      (github.event_name == 'pull_request' && github.event.action == 'closed') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/undeploy') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    steps:
+      # On a pull_request event checkout would default to the PR merge ref,
+      # which may be gone once the PR is closed and which would run PR supplied
+      # scripts on the runner. Pin the default branch explicitly.
+      - name: Checkout the default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+
+      - name: Tear down preview
+        env:
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: bash deploy/preview/teardown.sh "$PR"
+
+      - name: Comment on PR
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        with:
+          script: |
+            const marker = '<!-- arax-preview-status -->';
+            const pr = Number(process.env.PR_NUMBER);
+            if (!pr) {
+              core.info('no PR number available, nothing to comment on');
+              return;
+            }
+            const body = marker + '\n## ARAX preview\n\n🧹 ARAX preview for this PR was removed.';
+
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              per_page: 100,
+            });
+            const mine = existing.find(function (comment) {
+              return comment.body && comment.body.includes(marker);
+            });
+
+            if (mine) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: mine.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body: body,
+              });
+            }
+
+  gc:
+    name: Garbage collect previews
+    runs-on: [self-hosted, ARAX, docker]
+    timeout-minutes: 120
+    if: github.event_name == 'schedule'
+    steps:
+      # schedule events always run from the default branch, so the default
+      # checkout ref is already the right one.
+      - name: Checkout the default branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Garbage collect
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash deploy/preview/gc.sh

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -62,35 +62,15 @@ jobs:
         python -m pip install -r requirements.txt
         python code/ARAX/ARAXQuery/ARAX_database_manager.py --mnt --skip-if-exists --remove_unused
 
-    - name: Stop any running containers
+    # Scoped to this workflow's own container/image only. Other containers on the
+    # host (such as per-PR preview containers rtx_pr_<N>, see deploy/preview/README.md)
+    # must survive a CI run. Issue #2846.
+    - name: Clean up previous rtx_test container and image
       continue-on-error: true
       run: |
-            if [[ -n $(sudo docker ps -q) ]]; then
-                  sudo docker stop $(sudo docker ps -q)
-            else
-                  echo "No left over containers"
-            fi
+        sudo docker rm -f rtx_test 2>/dev/null || echo "No previous rtx_test container"
+        sudo docker rmi -f rtx:test 2>/dev/null || echo "No previous rtx:test image"
 
-    - name: Clean up any left over containers
-      continue-on-error: true
-      run: |
-           if [[ -n $(sudo docker ps -aq) ]]; then
-                  sudo docker rm $(sudo docker ps -aq)
-            else
-                  echo "No left over containers"
-            fi
-    
-    
-    - name: Clean up any left over images
-      continue-on-error: true
-      run: |
-            if [[ -n $(sudo docker images -aq) ]]; then
-                  sudo docker rmi -f $(sudo docker images -aq)
-            else
-                  echo "No left over images"
-            fi
-      
-    
     - name: Build docker image 
       run: sudo docker build --no-cache=true --rm --build-arg "BUILD_BRANCH=${{ github.head_ref || github.ref_name }}" -t rtx:test DockerBuild/ -f DockerBuild/CICD-Dockerfile
     - name: Run docker container
@@ -111,9 +91,11 @@ jobs:
     - name: Run tests with pytest
       run: sudo docker exec rtx_test bash -c "cd /mnt/data/orangeboard/production/RTX/code/ARAX/test && pytest -v --disable-pytest-warnings"
     
-    - name: Remove and delete all docker containers & images
+    - name: Remove rtx_test container and image
+      if: always()
       continue-on-error: true
       run: |
-        sudo docker stop $(sudo docker ps -aq)
-        sudo docker rm $(sudo docker ps -aq)
-        sudo docker rmi $(sudo docker images -q)
+        sudo docker rm -f rtx_test 2>/dev/null || echo "No rtx_test container"
+        sudo docker rmi -f rtx:test 2>/dev/null || echo "No rtx:test image"
+        # dangling layers only, never touches tagged images of other containers
+        sudo docker image prune -f

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,6 +18,10 @@ on:
       - 'requirements.txt'
       - '.github/workflows/pytest.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }} # this is the workflow name and the branch name
+  cancel-in-progress: true # this is to cancel the in-progress workflow if a new one is started
+
 jobs:
   analyze:
     name: Analyze

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -1,0 +1,230 @@
+# ARAX preview environments
+
+Every open pull request can get its own live ARAX instance on `cicd.rtx.ai`, built from that
+branch and reachable over HTTPS at a URL derived from the pull request number. The whole thing
+is a push button flow: comment `/deploy` on a pull request, wait for the build, and click the
+link that the bot posts back. This implements
+[issue #2846](https://github.com/RTXteam/RTX/issues/2846).
+
+`DockerBuild/test-instance-scripts/` is the older manual way of standing up a test instance on a
+fresh EC2 box and stays available for the cases this workflow does not cover.
+
+## URL and port scheme
+
+| thing | value for PR 2853 | how it is derived |
+| --- | --- | --- |
+| public URL | `https://cicd.rtx.ai/2853/` | `PREVIEW_PUBLIC_BASE_URL` + `/` + `PREVIEW_PATH_PREFIX` + PR + `/` |
+| host port | `127.0.0.1:12853` | `PREVIEW_PORT_BASE` + PR |
+| container | `rtx_pr_2853` | `rtx_pr_` + PR |
+| image | `rtx:pr-2853` | `rtx:pr-` + PR |
+| nginx snippet | `/etc/nginx/arax-preview.d/2853.conf` | `PREVIEW_NGINX_DIR` + `/` + `PREVIEW_PATH_PREFIX` + PR + `.conf` |
+
+The host port is bound to loopback only, so nothing is reachable from outside the box except
+through nginx on 443. `https://cicd.rtx.ai/2853` without the trailing slash redirects to
+`https://cicd.rtx.ai/2853/`.
+
+Setting `PREVIEW_PATH_PREFIX=pr-` moves the same preview to `https://cicd.rtx.ai/pr-2853/` and
+renames the snippet to `pr-2853.conf`. The port and the container name do not change.
+
+## How to deploy
+
+Three ways, all of which end up running the same scripts on the runner.
+
+- Comment `/deploy` on the pull request. Comment `/undeploy` to remove it again. Only comments
+  from an OWNER, MEMBER or COLLABORATOR are acted on.
+- Actions tab, pick **Preview Deploy**, **Run workflow**, fill in `pr_number`. Tick `run_tests`
+  to also run the ARAX test suite inside the container, and put anything extra in `pytest_args`.
+- On the host directly: `bash deploy/preview/deploy.sh 2853 my-branch`.
+
+The workflow posts one sticky comment on the pull request with the URL, the branch and short
+commit, and the smoke test table. Redeploying updates that same comment instead of adding a
+new one. A refused `/deploy` (fork pull request, closed pull request) gets a short reply saying
+why.
+
+The scripts always run from the workflow's own branch (master once merged, `issue-2846` while
+testing with **Run workflow**), never from the pull request. The pull request head is checked out
+into `pr-head/` and used only as the docker build context, so a pull request that changes
+`DockerBuild/CICD-Dockerfile` is built with its own Dockerfile, exactly as `pytest.yml` does.
+This also means a pull request opened before this tooling existed can be previewed.
+
+GitHub only fires `issue_comment` and `schedule` from the default branch copy of a workflow
+file. Until this workflow is merged to master, the only trigger that works is
+**Run workflow** against the `issue-2846` branch.
+
+## How it works
+
+```
+  PR comment "/deploy"  or  Actions "Run workflow"
+              |
+              v
+  +------------------------------------+
+  | GitHub Actions: Preview Deploy     |
+  |  resolve PR -> branch, sha         |
+  |  refuse fork PRs and closed PRs    |
+  +------------------------------------+
+              |  runs on the self-hosted runner
+              v
+  +------------------------------------------------------------+
+  | cicd.rtx.ai                                                 |
+  |                                                             |
+  |  deploy.sh                                                  |
+  |    docker build -f DockerBuild/CICD-Dockerfile              |
+  |      (the image git clones RTXteam/RTX and checks out       |
+  |       BUILD_BRANCH, so the branch must live upstream)       |
+  |         |                                                   |
+  |         v                                                   |
+  |    docker run -d -i -t --name rtx_pr_2853                   |
+  |      -p 127.0.0.1:12853:80                                  |
+  |      -v databases  -v config_secrets.json                   |
+  |         |                                                   |
+  |         +-> ARAX_database_manager.py   (db symlinks)        |
+  |         +-> kp_info_cacher.py          (KP info cache)      |
+  |         +-> service apache2 start                           |
+  |         +-> service RTX_OpenAPI_production start            |
+  |         +-> service RTX_Complete start                      |
+  |         |                                                   |
+  |         v                                                   |
+  |    write /etc/nginx/arax-preview.d/2853.conf                |
+  |    write /etc/nginx/arax-preview.d/_rtxcomplete.conf        |
+  |    nginx -t && systemctl reload nginx                       |
+  |         |                                                   |
+  |         v                                                   |
+  |    poll http://127.0.0.1:12853/api/arax/v1.4/status         |
+  |                                                             |
+  |  nginx :443  server_name cicd.rtx.ai                        |
+  |    include /etc/nginx/arax-preview.d/*.conf;                |
+  |      location /2853/ -> proxy_pass 127.0.0.1:12853/         |
+  |                          (the trailing slash strips /2853)  |
+  +------------------------------------------------------------+
+              |
+              v
+     https://cicd.rtx.ai/2853/
+```
+
+Inside the container, apache serves the ARAX UI from the checked out repository and proxies
+`/api/arax/v1.4` to the Flask service on port 5000. The UI asks for its API with a relative
+path, so it does not care that nginx stripped a prefix in front of it.
+
+## One-time host setup
+
+Run this once on `cicd.rtx.ai`, as a human with sudo:
+
+```
+sudo bash deploy/preview/install-nginx-include.sh
+```
+
+It creates `/etc/nginx/arax-preview.d/`, backs up `/etc/nginx/sites-enabled/default`, and adds
+one line inside the certbot managed TLS server block for `cicd.rtx.ai`:
+
+```
+    include /etc/nginx/arax-preview.d/*.conf;
+```
+
+Then it runs `nginx -t` and reloads. If the check fails the backup is restored. If no matching
+server block is found nothing is written and the script prints the manual instructions. Running
+it a second time detects the existing line and exits without touching anything.
+
+The runner user needs passwordless sudo for `docker`, `nginx`, `systemctl reload nginx`, `tee`,
+`rm` and `mkdir`. This is already true on `cicd.rtx.ai`, because `.github/workflows/pytest.yml`
+calls `sudo docker` with no terminal attached. Confirm it as the runner user with `sudo -n true`.
+
+### Environment variables
+
+Everything below is read by `deploy/preview/lib.sh` and can be overridden in the environment.
+
+| variable | default | meaning |
+| --- | --- | --- |
+| `PREVIEW_PATH_PREFIX` | empty | text placed in front of the PR number in the URL and the snippet name |
+| `PREVIEW_PORT_BASE` | `10000` | host port is this plus the PR number |
+| `PREVIEW_NGINX_DIR` | `/etc/nginx/arax-preview.d` | where the per-PR nginx snippets live |
+| `PREVIEW_PUBLIC_BASE_URL` | `https://cicd.rtx.ai` | scheme and host used to build the public URL |
+| `PREVIEW_DB_DIR` | `/mnt/data/orangeboard/databases` | host database directory mounted into every preview |
+| `PREVIEW_CONFIG_SECRETS` | `/mnt/config/config_secrets.json` | host secrets file mounted into every preview |
+| `PREVIEW_TTL_DAYS` | `7` | age after which garbage collection removes a preview |
+| `PREVIEW_HEALTH_TIMEOUT` | `900` | seconds to wait for the ARAX status endpoint after start |
+| `PREVIEW_REPO` | `RTXteam/RTX` | repository the pull request state is checked against |
+| `PREVIEW_BUILD_CONTEXT` | `<repo>/DockerBuild` | docker build context, the workflow points it at `pr-head/DockerBuild` |
+| `PREVIEW_DOCKERFILE` | `$PREVIEW_BUILD_CONTEXT/CICD-Dockerfile` | Dockerfile used for the image |
+| `PREVIEW_NGINX_SITE` | `/etc/nginx/sites-enabled/default` | site file edited by `install-nginx-include.sh` |
+| `DOCKER` | `sudo docker` | docker command used by every script |
+| `SUDO` | `sudo` | privilege escalation command used by every script |
+
+## The shared `/rtxcomplete/` caveat
+
+`code/UI/interactive/index.html` and `rtxcompletenode.js` load the autocomplete service with a
+root absolute path, `/rtxcomplete/...`, not a relative one. That path has no PR number in it, so
+it cannot be routed per preview. All previews on the box therefore share a single
+`/rtxcomplete/` route, and `deploy.sh` points it at the preview that was deployed most recently.
+
+What this means in practice: autocomplete suggestions in an older preview come from the newest
+preview's container. Everything else, including the whole ARAX API, is properly isolated per
+pull request. Tearing down the newest preview repoints `/rtxcomplete/` at whichever preview is
+next newest, and removes the route entirely when no previews are left.
+
+## Lifecycle
+
+- **Redeploy** replaces. `deploy.sh` removes the existing container and image for that PR before
+  it builds, so the URL stays the same and always serves the latest push you deployed.
+- **Teardown on close.** Closing or merging a pull request triggers the teardown job, which
+  removes the container, the image and the nginx snippet.
+- **Daily garbage collection.** A scheduled run of `gc.sh` removes previews older than
+  `PREVIEW_TTL_DAYS` and previews whose pull request is no longer open. Merged pull requests
+  count as closed. Without a GitHub token the age rule is the only one that applies.
+
+## Manual operations
+
+```
+# deploy or redeploy a preview
+bash deploy/preview/deploy.sh 2853 my-branch
+
+# remove one preview
+bash deploy/preview/teardown.sh 2853
+
+# see what garbage collection would do, without doing it
+bash deploy/preview/gc.sh --dry-run
+
+# smoke test a running preview, optionally with the test suite
+bash deploy/preview/smoke.sh 2853
+bash deploy/preview/smoke.sh 2853 --pytest "-k test_ARAX_query"
+
+# list every preview on the box
+sudo docker ps --filter label=arax.preview=true
+
+# one time host setup
+sudo bash deploy/preview/install-nginx-include.sh
+```
+
+## Limitations
+
+- **Same repository branches only.** `DockerBuild/CICD-Dockerfile` clones `RTXteam/RTX` inside
+  the image and checks out `BUILD_BRANCH`, so a branch that only exists on a fork cannot be
+  built. The workflow refuses fork pull requests with a clear message rather than failing
+  halfway through a build.
+- **One box, shared resources.** Previews run on the same EC2 instance as the pytest workflow
+  and as every other preview. Several previews at once compete for memory and disk. Keep the
+  number of live previews small and let garbage collection do its job.
+- **Plain HTTP inside the box.** TLS terminates at nginx. The container speaks HTTP on a
+  loopback port and is not reachable from outside the host on its own.
+- **Shared `/rtxcomplete/`.** See the section above.
+- **Startup is slow.** A cold preview takes several minutes to answer, because the image is
+  built with `--no-cache` and the container has to build the knowledge provider info cache
+  before the API responds.
+- **A host reboot needs a redeploy.** The container has no init system, apache and the Flask
+  services are started with `docker exec` after `docker run`. If `cicd.rtx.ai` reboots the
+  containers may come back but the services inside them do not. Comment `/deploy` again.
+- **`pytest.yml` must stay scoped.** The pytest workflow used to stop and delete every container
+  and image on the host. It now only touches `rtx_test` and `rtx:test`. Reverting that change
+  would kill every preview on each CI run.
+
+## Security note
+
+Previews run on a self-hosted runner that mounts real database files and a real
+`config_secrets.json` into the container. Anyone who can make that runner execute arbitrary code
+gets those secrets. Two guards follow from that:
+
+- `/deploy` and `/undeploy` are only honoured when the comment author association is `OWNER`,
+  `MEMBER` or `COLLABORATOR`. A drive-by comment from an outside contributor does nothing.
+- Fork pull requests are refused outright.
+
+Preview URLs are unauthenticated and anybody who knows the pull request number can reach one.
+Treat a preview as public and do not put anything sensitive into a preview query.

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -41,15 +41,17 @@ commit, and the smoke test table. Redeploying updates that same comment instead 
 new one. A refused `/deploy` (fork pull request, closed pull request) gets a short reply saying
 why.
 
-The scripts always run from the workflow's own branch (master once merged, `issue-2846` while
-testing with **Run workflow**), never from the pull request. The pull request head is checked out
+The scripts always run from the workflow's own branch on master, never from the pull
+request. The pull request head is checked out
 into `pr-head/` and used only as the docker build context, so a pull request that changes
 `DockerBuild/CICD-Dockerfile` is built with its own Dockerfile, exactly as `pytest.yml` does.
 This also means a pull request opened before this tooling existed can be previewed.
 
-GitHub only fires `issue_comment` and `schedule` from the default branch copy of a workflow
-file. Until this workflow is merged to master, the only trigger that works is
-**Run workflow** against the `issue-2846` branch.
+GitHub only registers a workflow, and only fires `workflow_dispatch`, `issue_comment` and
+`schedule`, from the default branch copy of the file. Until this workflow is merged to master
+no GitHub trigger works at all, not even **Run workflow**, because the workflow does not appear
+in the Actions tab. Test on the host with `deploy/preview/deploy.sh` until then, and verify the
+triggers immediately after the merge.
 
 ## How it works
 
@@ -113,7 +115,9 @@ Run this once on `cicd.rtx.ai`, as a human with sudo:
 sudo bash deploy/preview/install-nginx-include.sh
 ```
 
-It creates `/etc/nginx/arax-preview.d/`, backs up `/etc/nginx/sites-enabled/default`, and adds
+It creates `/etc/nginx/arax-preview.d/`, backs up `/etc/nginx/sites-enabled/default` into
+`/var/backups/arax-preview/` (a backup inside `sites-enabled/` would itself be parsed as
+configuration, Ubuntu's nginx.conf includes that directory with a bare glob), and adds
 one line inside the certbot managed TLS server block for `cicd.rtx.ai`:
 
 ```

--- a/deploy/preview/deploy.sh
+++ b/deploy/preview/deploy.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# Deploy one ARAX preview environment for a pull request on cicd.rtx.ai.
+# Idempotent: running it again replaces the container, the image and the
+# nginx snippet for that PR.
+#
+# Usage: deploy.sh <PR> <BRANCH> [SHA]
+#
+# Issue #2846.
+
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+usage() {
+    cat >&2 <<'USAGE_EOF'
+Usage: deploy.sh <PR> <BRANCH> [SHA]
+
+  PR      pull request number, for example 2853
+  BRANCH  branch name on RTXteam/RTX, for example issue-2846
+  SHA     optional commit sha, recorded as a container label only
+USAGE_EOF
+    exit 2
+}
+
+# ---------------------------------------------------------------------------
+# 1. Validate arguments and the host setup
+# ---------------------------------------------------------------------------
+
+[ "$#" -ge 2 ] || usage
+
+PR="$1"
+BRANCH="$2"
+SHA="${3:-unknown}"
+
+require_int "${PR}" "PR number"
+[ -n "${BRANCH}" ] || die "branch name must not be empty"
+
+PORT="$(preview_port "${PR}")"
+CONTAINER="$(preview_container "${PR}")"
+IMAGE="$(preview_image "${PR}")"
+PUBLIC_PATH="$(preview_path "${PR}")"
+PUBLIC_URL="$(preview_url "${PR}")"
+NGINX_CONF="$(preview_nginx_conf "${PR}")"
+
+log "step 1/8 validating host setup"
+log "PR ${PR}, branch ${BRANCH}, sha ${SHA}"
+log "container ${CONTAINER}, image ${IMAGE}, port 127.0.0.1:${PORT}"
+log "public url ${PUBLIC_URL}"
+
+if ! ${SUDO} test -d "${PREVIEW_NGINX_DIR}"; then
+    die "${PREVIEW_NGINX_DIR} does not exist. Run deploy/preview/install-nginx-include.sh once on this host as a human with sudo."
+fi
+if ! ${SUDO} test -w "${PREVIEW_NGINX_DIR}"; then
+    die "${PREVIEW_NGINX_DIR} is not writable through sudo. Run deploy/preview/install-nginx-include.sh once on this host as a human with sudo."
+fi
+[ -f "${PREVIEW_DOCKERFILE}" ] || die "Dockerfile ${PREVIEW_DOCKERFILE} not found. Set PREVIEW_BUILD_CONTEXT to a checkout's DockerBuild directory."
+log "build context ${PREVIEW_BUILD_CONTEXT}, dockerfile ${PREVIEW_DOCKERFILE}"
+
+# ---------------------------------------------------------------------------
+# 2. Remove anything left over from a previous deploy of this PR
+# ---------------------------------------------------------------------------
+
+log "step 2/8 removing any previous container and image for PR ${PR}"
+${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || log "no previous container ${CONTAINER}"
+${DOCKER} rmi -f "${IMAGE}" >/dev/null 2>&1 || log "no previous image ${IMAGE}"
+
+# ---------------------------------------------------------------------------
+# 3. Build the image
+# ---------------------------------------------------------------------------
+
+# CICD-Dockerfile git clones RTXteam/RTX inside the image and checks out
+# BUILD_BRANCH, so the branch has to exist on the upstream repository. Fork
+# pull requests cannot work with this build and are refused by the workflow.
+log "step 3/8 building ${IMAGE} from branch ${BRANCH} (this takes a while)"
+${DOCKER} build \
+    --no-cache=true \
+    --rm \
+    --build-arg "BUILD_BRANCH=${BRANCH}" \
+    -t "${IMAGE}" \
+    -f "${PREVIEW_DOCKERFILE}" \
+    "${PREVIEW_BUILD_CONTEXT}/"
+
+# ---------------------------------------------------------------------------
+# 4. Run the container and start the services inside it
+# ---------------------------------------------------------------------------
+
+CREATED="$(date -u '+%s')"
+
+# The image has no CMD and no ENTRYPOINT, so it needs -d -i -t to stay up,
+# exactly like the pytest workflow does.
+log "step 4/8 starting ${CONTAINER} on 127.0.0.1:${PORT}"
+${DOCKER} run -d -i -t \
+    --name "${CONTAINER}" \
+    -p "127.0.0.1:${PORT}:80" \
+    -v "${PREVIEW_DB_DIR}:/mnt/data/orangeboard/databases" \
+    -v "${PREVIEW_CONFIG_SECRETS}:/mnt/data/orangeboard/production/RTX/code/config_secrets.json" \
+    --label "arax.preview=true" \
+    --label "arax.preview.pr=${PR}" \
+    --label "arax.preview.branch=${BRANCH}" \
+    --label "arax.preview.sha=${SHA}" \
+    --label "arax.preview.created=${CREATED}" \
+    "${IMAGE}"
+
+log "creating database symlinks"
+${DOCKER} exec "${CONTAINER}" bash -c "sudo -u rt bash -c 'cd /mnt/data/orangeboard/production/RTX && python3 code/ARAX/ARAXQuery/ARAX_database_manager.py'"
+
+log "building the KP info cache"
+${DOCKER} exec "${CONTAINER}" bash -c "cd /mnt/data/orangeboard/production/RTX/code/ARAX/ARAXQuery/Expand && python3 kp_info_cacher.py"
+
+log "starting apache2, RTX_OpenAPI_production and RTX_Complete"
+${DOCKER} exec "${CONTAINER}" service apache2 start
+${DOCKER} exec "${CONTAINER}" service RTX_OpenAPI_production start
+${DOCKER} exec "${CONTAINER}" service RTX_Complete start
+
+# ---------------------------------------------------------------------------
+# 5. Publish the preview through nginx
+# ---------------------------------------------------------------------------
+
+log "step 5/8 writing ${NGINX_CONF}"
+
+# Keep a copy of the shared autocomplete snippet so a failed nginx -t can be
+# rolled back to exactly what was there before.
+RTXCOMPLETE_BACKUP=""
+if ${SUDO} test -f "${PREVIEW_RTXCOMPLETE_CONF}"; then
+    RTXCOMPLETE_BACKUP="$(mktemp)"
+    ${SUDO} cat "${PREVIEW_RTXCOMPLETE_CONF}" > "${RTXCOMPLETE_BACKUP}"
+fi
+
+rollback_nginx() {
+    ${SUDO} rm -f "${NGINX_CONF}"
+    if [ -n "${RTXCOMPLETE_BACKUP}" ]; then
+        ${SUDO} tee "${PREVIEW_RTXCOMPLETE_CONF}" >/dev/null < "${RTXCOMPLETE_BACKUP}"
+    else
+        ${SUDO} rm -f "${PREVIEW_RTXCOMPLETE_CONF}"
+    fi
+    rm -f "${RTXCOMPLETE_BACKUP}"
+    # Best effort: put nginx back on the configuration it had before.
+    nginx_reload || log "nginx did not reload after rollback, inspect the host by hand"
+}
+
+# The trailing slash on proxy_pass is what strips the /<PR>/ prefix before the
+# request reaches apache in the container.
+${SUDO} tee "${NGINX_CONF}" >/dev/null <<NGINX_EOF
+# managed by deploy/preview/deploy.sh, PR ${PR}, branch ${BRANCH}, sha ${SHA}, created $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+location = ${PUBLIC_PATH} { return 301 ${PUBLIC_PATH}/; }
+location ${PUBLIC_PATH}/ {
+    proxy_pass http://127.0.0.1:${PORT}/;
+    proxy_read_timeout 3000s;
+    proxy_buffering off;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header X-Forwarded-Prefix ${PUBLIC_PATH};
+}
+NGINX_EOF
+
+write_rtxcomplete_conf "${PORT}" "${PR}"
+
+if ! nginx_reload; then
+    rollback_nginx
+    die "nginx rejected the preview configuration for PR ${PR}, rolled back"
+fi
+rm -f "${RTXCOMPLETE_BACKUP}"
+
+# ---------------------------------------------------------------------------
+# 6. Wait for the ARAX API to come up
+# ---------------------------------------------------------------------------
+
+HEALTH_URL="http://127.0.0.1:${PORT}/api/arax/v1.4/status"
+log "step 6/8 polling ${HEALTH_URL} for up to ${PREVIEW_HEALTH_TIMEOUT}s"
+
+DEADLINE=$(( $(date -u '+%s') + PREVIEW_HEALTH_TIMEOUT ))
+HEALTHY="no"
+while [ "$(date -u '+%s')" -lt "${DEADLINE}" ]; do
+    if curl -fsS -o /dev/null -m 15 "${HEALTH_URL}"; then
+        HEALTHY="yes"
+        break
+    fi
+    sleep 10
+done
+
+if [ "${HEALTHY}" != "yes" ]; then
+    log "the preview never answered ${HEALTH_URL}, last 200 lines of container output follow"
+    ${DOCKER} logs --tail 200 "${CONTAINER}" >&2 || true
+    die "PR ${PR} preview failed its health check after ${PREVIEW_HEALTH_TIMEOUT}s"
+fi
+log "health check passed"
+
+# ---------------------------------------------------------------------------
+# 7. Check the public URL, without failing the deploy on it
+# ---------------------------------------------------------------------------
+
+log "step 7/8 checking the public URL"
+if curl -fsS -o /dev/null -m 20 "${PUBLIC_URL}api/arax/v1.4/status"; then
+    log "public url ok: ${PUBLIC_URL}"
+else
+    log "WARNING: ${PUBLIC_URL}api/arax/v1.4/status did not answer. The container is healthy, so this points at nginx or DNS on the host."
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Summary
+# ---------------------------------------------------------------------------
+
+log "step 8/8 done"
+cat <<SUMMARY_EOF
+=====================================================
+ARAX preview deployed
+  pr        ${PR}
+  branch    ${BRANCH}
+  sha       ${SHA}
+  url       ${PUBLIC_URL}
+  port      127.0.0.1:${PORT}
+  container ${CONTAINER}
+  image     ${IMAGE}
+  nginx     ${NGINX_CONF}
+=====================================================
+SUMMARY_EOF
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        printf 'url=%s\n' "${PUBLIC_URL}"
+        printf 'port=%s\n' "${PORT}"
+        printf 'container=%s\n' "${CONTAINER}"
+        printf 'image=%s\n' "${IMAGE}"
+        printf 'path=%s\n' "${PUBLIC_PATH}"
+    } >> "${GITHUB_OUTPUT}"
+fi

--- a/deploy/preview/gc.sh
+++ b/deploy/preview/gc.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Garbage collect ARAX preview environments on cicd.rtx.ai. A preview goes
+# away when it is older than the time to live, or when its pull request is no
+# longer open. Merged pull requests are closed pull requests, so the state
+# check covers them.
+#
+# Usage: gc.sh [--ttl-days N] [--dry-run]
+#
+# Set GITHUB_TOKEN or GH_TOKEN to enable the pull request state check. Without
+# a token only the age rule applies.
+#
+# Issue #2846.
+
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+DRY_RUN="no"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --ttl-days)
+            PREVIEW_TTL_DAYS="${2:-}"
+            require_int "${PREVIEW_TTL_DAYS}" "--ttl-days"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN="yes"
+            shift
+            ;;
+        -h|--help)
+            printf 'Usage: gc.sh [--ttl-days N] [--dry-run]\n' >&2
+            exit 0
+            ;;
+        *)
+            die "unknown argument '$1'"
+            ;;
+    esac
+done
+
+TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+TTL_SECONDS=$(( PREVIEW_TTL_DAYS * 86400 ))
+NOW="$(date -u '+%s')"
+
+log "garbage collecting previews, ttl ${PREVIEW_TTL_DAYS} days, dry run ${DRY_RUN}"
+if [ -z "${TOKEN}" ]; then
+    log "no GITHUB_TOKEN or GH_TOKEN in the environment, checking age only"
+fi
+
+# Asks the GitHub API whether a pull request is still open. Prints one of
+# open, closed or unknown. Kept deliberately tolerant: a rate limited or
+# unreachable API must never delete somebody's preview.
+pr_state() {
+    local pr="$1"
+    local body
+    body="$(curl -fsS -m 30 \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${PREVIEW_REPO}/pulls/${pr}" 2>/dev/null || true)"
+    if [ -z "${body}" ]; then
+        printf 'unknown'
+        return 0
+    fi
+    # python3.8 on the host, so no walrus and no match statement here
+    printf '%s' "${body}" | python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.stdout.write("unknown")
+    sys.exit(0)
+
+state = data.get("state")
+merged = data.get("merged")
+if state == "closed" or merged is True:
+    sys.stdout.write("closed")
+elif state == "open":
+    sys.stdout.write("open")
+else:
+    sys.stdout.write("unknown")
+'
+}
+
+human_age() {
+    local seconds="$1"
+    local days=$(( seconds / 86400 ))
+    local hours=$(( (seconds % 86400) / 3600 ))
+    printf '%sd%sh' "${days}" "${hours}"
+}
+
+PRS="$(list_preview_prs | sort -n -u)"
+
+if [ -z "${PRS}" ]; then
+    printf 'No ARAX previews found on this host.\n'
+    exit 0
+fi
+
+ROWS=()
+TO_REMOVE=()
+
+for pr in ${PRS}; do
+    created="$(preview_label "${pr}" 'arax.preview.created')"
+    branch="$(preview_label "${pr}" 'arax.preview.branch')"
+    [ -n "${branch}" ] || branch="unknown"
+
+    case "${created}" in
+        ''|*[!0-9]*)
+            # A preview without a usable timestamp is treated as too old to
+            # keep, because nothing else can tell us when it was made.
+            age_seconds="${TTL_SECONDS}"
+            age_text="unknown"
+            expired="yes"
+            ;;
+        *)
+            age_seconds=$(( NOW - created ))
+            age_text="$(human_age "${age_seconds}")"
+            if [ "${age_seconds}" -gt "${TTL_SECONDS}" ]; then
+                expired="yes"
+            else
+                expired="no"
+            fi
+            ;;
+    esac
+
+    state="skipped"
+    if [ -n "${TOKEN}" ]; then
+        state="$(pr_state "${pr}")"
+    fi
+
+    decision="keep"
+    if [ "${expired}" = "yes" ]; then
+        decision="remove, older than ${PREVIEW_TTL_DAYS} days"
+    fi
+    if [ "${state}" = "closed" ]; then
+        decision="remove, pull request is closed"
+    fi
+
+    ROWS+=("| ${pr} | ${age_text} | ${branch} | ${state} | ${decision} |")
+    case "${decision}" in
+        remove*) TO_REMOVE+=("${pr}") ;;
+    esac
+done
+
+printf '| pr | age | branch | pr state | decision |\n'
+printf '| --- | --- | --- | --- | --- |\n'
+for row in "${ROWS[@]}"; do
+    printf '%s\n' "${row}"
+done
+printf '\n'
+
+if [ "${#TO_REMOVE[@]}" -eq 0 ]; then
+    printf 'Nothing to remove.\n'
+else
+    for pr in "${TO_REMOVE[@]}"; do
+        if [ "${DRY_RUN}" = "yes" ]; then
+            printf 'dry run: would tear down PR %s\n' "${pr}"
+        else
+            log "tearing down PR ${pr}"
+            "${SCRIPT_DIR}/teardown.sh" "${pr}" || log "WARNING: teardown of PR ${pr} failed"
+        fi
+    done
+fi
+
+if [ "${DRY_RUN}" = "yes" ]; then
+    printf 'dry run: would run docker image prune -f\n'
+else
+    # Dangling layers only. Tagged images belonging to live previews and to the
+    # pytest workflow are never touched by this.
+    log "pruning dangling images"
+    ${DOCKER} image prune -f
+fi

--- a/deploy/preview/install-nginx-include.sh
+++ b/deploy/preview/install-nginx-include.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# One time host setup for the ARAX preview environments on cicd.rtx.ai.
+# A human runs this once, as root or with sudo. Everything the deploy workflow
+# does afterwards stays inside PREVIEW_NGINX_DIR and never edits the certbot
+# managed site file again.
+#
+# Usage: sudo bash deploy/preview/install-nginx-include.sh
+#
+# Issue #2846.
+
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+# The certbot managed site file on cicd.rtx.ai, set up by
+# tests/setup-ci-report-append-logfile-webroot.sh.
+PREVIEW_NGINX_SITE="${PREVIEW_NGINX_SITE:-/etc/nginx/sites-enabled/default}"
+INCLUDE_LINE="    include ${PREVIEW_NGINX_DIR}/*.conf;"
+INCLUDE_MARKER="include ${PREVIEW_NGINX_DIR}/*.conf;"
+
+log "installing the ARAX preview include into ${PREVIEW_NGINX_SITE}"
+
+[ -f "${PREVIEW_NGINX_SITE}" ] || die "${PREVIEW_NGINX_SITE} does not exist. Set PREVIEW_NGINX_SITE to the certbot managed site file for cicd.rtx.ai."
+
+# ---------------------------------------------------------------------------
+# The snippet directory
+# ---------------------------------------------------------------------------
+
+${SUDO} mkdir -p "${PREVIEW_NGINX_DIR}"
+${SUDO} chmod 755 "${PREVIEW_NGINX_DIR}"
+log "${PREVIEW_NGINX_DIR} is ready"
+
+# ---------------------------------------------------------------------------
+# The include line
+# ---------------------------------------------------------------------------
+
+if ${SUDO} grep -qF "${INCLUDE_MARKER}" "${PREVIEW_NGINX_SITE}"; then
+    printf 'already installed: %s already contains "%s"\n' "${PREVIEW_NGINX_SITE}" "${INCLUDE_MARKER}"
+    exit 0
+fi
+
+TIMESTAMP="$(date -u '+%Y%m%d%H%M%S')"
+BACKUP="${PREVIEW_NGINX_SITE}.bak.${TIMESTAMP}"
+${SUDO} cp -p "${PREVIEW_NGINX_SITE}" "${BACKUP}"
+log "backed up ${PREVIEW_NGINX_SITE} to ${BACKUP}"
+
+# Brace counting beats a sed regex here, because we have to be sure we land in
+# the TLS server block and not in the plain port 80 redirect block.
+INSERTER="$(mktemp)"
+cat > "${INSERTER}" <<'PYTHON_EOF'
+import sys
+
+path = sys.argv[1]
+include_line = sys.argv[2]
+server_name_needle = sys.argv[3]
+
+with open(path, "r") as handle:
+    lines = handle.readlines()
+
+# Walk the file and record every top level "server { ... }" block as a
+# (start_index, end_index_exclusive) pair.
+blocks = []
+depth = 0
+start = None
+for index, line in enumerate(lines):
+    stripped = line.strip()
+    if depth == 0 and stripped.startswith("server") and "{" in stripped:
+        start = index
+    depth += line.count("{") - line.count("}")
+    if start is not None and depth <= 0:
+        blocks.append((start, index + 1))
+        start = None
+        depth = 0
+
+for begin, end in blocks:
+    body = lines[begin:end]
+    has_tls = any("listen" in item and "443" in item for item in body)
+    if not has_tls:
+        continue
+    for offset, item in enumerate(body):
+        if item.strip() == server_name_needle:
+            insert_at = begin + offset + 1
+            lines.insert(insert_at, include_line + "\n")
+            with open(path, "w") as handle:
+                handle.writelines(lines)
+            sys.stdout.write(str(insert_at + 1))
+            sys.exit(0)
+
+sys.exit(3)
+PYTHON_EOF
+
+set +o errexit
+INSERTED_AT="$(${SUDO} python3 "${INSERTER}" "${PREVIEW_NGINX_SITE}" "${INCLUDE_LINE}" 'server_name cicd.rtx.ai;')"
+INSERT_RC=$?
+set -o errexit
+rm -f "${INSERTER}"
+
+if [ "${INSERT_RC}" -ne 0 ]; then
+    ${SUDO} rm -f "${BACKUP}"
+    cat >&2 <<MANUAL_EOF
+
+Could not find a server block in ${PREVIEW_NGINX_SITE} that has both a
+"listen ... 443" line and a "server_name cicd.rtx.ai;" line. Nothing was
+changed.
+
+Add the include by hand instead. Open ${PREVIEW_NGINX_SITE}, find the TLS
+server block that certbot manages for cicd.rtx.ai, and add this single line
+just after its server_name line, inside the braces of that server block:
+
+${INCLUDE_LINE}
+
+Then run:
+
+    sudo nginx -t && sudo systemctl reload nginx
+
+MANUAL_EOF
+    exit 1
+fi
+
+log "inserted the include at line ${INSERTED_AT} of ${PREVIEW_NGINX_SITE}"
+
+# ---------------------------------------------------------------------------
+# Validate, and undo the edit if nginx does not like it
+# ---------------------------------------------------------------------------
+
+if ! ${SUDO} nginx -t; then
+    ${SUDO} cp -p "${BACKUP}" "${PREVIEW_NGINX_SITE}"
+    log "nginx -t failed, restored ${PREVIEW_NGINX_SITE} from ${BACKUP}"
+    die "nginx rejected the edited configuration, nothing was changed"
+fi
+
+${SUDO} systemctl reload nginx
+log "nginx reloaded"
+
+cat <<NOTE_EOF
+
+Installed.
+
+  site file      ${PREVIEW_NGINX_SITE}
+  backup         ${BACKUP}
+  snippet dir    ${PREVIEW_NGINX_DIR}
+  include line   ${INCLUDE_LINE}
+
+The GitHub Actions runner user also needs passwordless sudo for docker, nginx,
+systemctl reload nginx, tee, rm and mkdir. That is already the case on
+cicd.rtx.ai, because .github/workflows/pytest.yml calls "sudo docker" with no
+terminal attached. Check it as the runner user with:
+
+    sudo -n true && echo "passwordless sudo works"
+
+Deploy a preview with:
+
+    bash deploy/preview/deploy.sh <PR> <BRANCH>
+
+NOTE_EOF

--- a/deploy/preview/install-nginx-include.sh
+++ b/deploy/preview/install-nginx-include.sh
@@ -43,7 +43,10 @@ if ${SUDO} grep -qF "${INCLUDE_MARKER}" "${PREVIEW_NGINX_SITE}"; then
 fi
 
 TIMESTAMP="$(date -u '+%Y%m%d%H%M%S')"
-BACKUP="${PREVIEW_NGINX_SITE}.bak.${TIMESTAMP}"
+
+BACKUP_DIR="${PREVIEW_NGINX_DIR_BACKUP_DIR:-/var/backups/arax-preview}"
+${SUDO} mkdir -p "${BACKUP_DIR}"
+BACKUP="${BACKUP_DIR}/$(basename "${PREVIEW_NGINX_SITE}").bak.${TIMESTAMP}"
 ${SUDO} cp -p "${PREVIEW_NGINX_SITE}" "${BACKUP}"
 log "backed up ${PREVIEW_NGINX_SITE} to ${BACKUP}"
 

--- a/deploy/preview/lib.sh
+++ b/deploy/preview/lib.sh
@@ -1,0 +1,219 @@
+# shellcheck shell=bash
+#
+# Shared helpers for the per-PR ARAX preview environments on cicd.rtx.ai.
+# Issue #2846.
+#
+# This file is sourced, never executed. Callers own the shell options
+# (set -o nounset -o pipefail -o errexit) so that sourcing this file cannot
+# change the behaviour of an interactive shell.
+
+# Absolute location of this library, so the scripts work no matter where they
+# are invoked from. We never rely on $PWD.
+PREVIEW_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# deploy/preview -> repository root is two levels up
+REPO_ROOT="$(cd "${PREVIEW_LIB_DIR}/../.." && pwd)"
+export PREVIEW_LIB_DIR REPO_ROOT
+
+# ---------------------------------------------------------------------------
+# Defaults. Every one of these can be overridden from the environment.
+# ---------------------------------------------------------------------------
+
+# Public path prefix in front of the PR number. Empty means PR 2853 is served
+# at /2853/. Setting it to "pr-" yields /pr-2853/.
+PREVIEW_PATH_PREFIX="${PREVIEW_PATH_PREFIX:-}"
+# Host port for a preview is PREVIEW_PORT_BASE + PR number, bound to loopback.
+PREVIEW_PORT_BASE="${PREVIEW_PORT_BASE:-10000}"
+# Directory of per-PR nginx snippets, included from the 443 server block.
+PREVIEW_NGINX_DIR="${PREVIEW_NGINX_DIR:-/etc/nginx/arax-preview.d}"
+# Scheme and host the previews are reachable at from the outside.
+PREVIEW_PUBLIC_BASE_URL="${PREVIEW_PUBLIC_BASE_URL:-https://cicd.rtx.ai}"
+# Host paths bind-mounted into every preview container, same as pytest.yml.
+PREVIEW_DB_DIR="${PREVIEW_DB_DIR:-/mnt/data/orangeboard/databases}"
+PREVIEW_CONFIG_SECRETS="${PREVIEW_CONFIG_SECRETS:-/mnt/config/config_secrets.json}"
+# Garbage collection age limit in days.
+PREVIEW_TTL_DAYS="${PREVIEW_TTL_DAYS:-7}"
+# Seconds to wait for the ARAX Flask service to answer /status after start.
+PREVIEW_HEALTH_TIMEOUT="${PREVIEW_HEALTH_TIMEOUT:-900}"
+# Repository the previews are built from. CICD-Dockerfile clones this by name.
+PREVIEW_REPO="${PREVIEW_REPO:-RTXteam/RTX}"
+# Docker build context and Dockerfile. The workflow points these at a checkout
+# of the PR head so that a PR can change the Dockerfile itself, while the
+# scripts run from the trusted default branch copy.
+PREVIEW_BUILD_CONTEXT="${PREVIEW_BUILD_CONTEXT:-${REPO_ROOT}/DockerBuild}"
+PREVIEW_DOCKERFILE="${PREVIEW_DOCKERFILE:-${PREVIEW_BUILD_CONTEXT}/CICD-Dockerfile}"
+
+# The runner user on cicd.rtx.ai has passwordless sudo and the existing
+# pytest.yml workflow already shells out to "sudo docker", so we do the same.
+DOCKER="${DOCKER:-sudo docker}"
+# Note the ${SUDO-sudo} form rather than ${SUDO:-sudo}: setting SUDO to an
+# empty string is a supported way to say "this shell is already root".
+SUDO="${SUDO-sudo}"
+
+export PREVIEW_PATH_PREFIX PREVIEW_PORT_BASE PREVIEW_NGINX_DIR \
+    PREVIEW_PUBLIC_BASE_URL PREVIEW_DB_DIR PREVIEW_CONFIG_SECRETS \
+    PREVIEW_TTL_DAYS PREVIEW_HEALTH_TIMEOUT PREVIEW_REPO \
+    PREVIEW_BUILD_CONTEXT PREVIEW_DOCKERFILE DOCKER SUDO
+
+# Name of the shared autocomplete snippet. Leading underscore keeps it sorted
+# ahead of the numeric per-PR files, which is only cosmetic.
+PREVIEW_RTXCOMPLETE_CONF="${PREVIEW_NGINX_DIR}/_rtxcomplete.conf"
+export PREVIEW_RTXCOMPLETE_CONF
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+# Logs go to stderr so that stdout stays clean for tables and summaries that
+# get pasted into PR comments.
+log() {
+    printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >&2
+}
+
+die() {
+    printf '[%s] ERROR: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Naming helpers
+# ---------------------------------------------------------------------------
+
+# require_int <value> <name>
+# Fails unless the value is a positive integer with no leading sign or zero.
+require_int() {
+    local value="${1:-}"
+    local name="${2:-value}"
+    case "${value}" in
+        ''|*[!0-9]*) die "${name} must be a positive integer, got '${value}'" ;;
+    esac
+    if [ "${value}" -le 0 ] 2>/dev/null; then
+        die "${name} must be a positive integer, got '${value}'"
+    fi
+}
+
+preview_port() {
+    local pr="${1:-}"
+    require_int "${pr}" "PR number"
+    printf '%s\n' "$(( PREVIEW_PORT_BASE + pr ))"
+}
+
+preview_container() {
+    local pr="${1:-}"
+    require_int "${pr}" "PR number"
+    printf 'rtx_pr_%s\n' "${pr}"
+}
+
+preview_image() {
+    local pr="${1:-}"
+    require_int "${pr}" "PR number"
+    printf 'rtx:pr-%s\n' "${pr}"
+}
+
+# Public path without a trailing slash, for example /2853 or /pr-2853.
+preview_path() {
+    local pr="${1:-}"
+    require_int "${pr}" "PR number"
+    printf '/%s%s\n' "${PREVIEW_PATH_PREFIX}" "${pr}"
+}
+
+# Public URL with a trailing slash, which is what a browser needs.
+preview_url() {
+    local pr="${1:-}"
+    require_int "${pr}" "PR number"
+    printf '%s/%s%s/\n' "${PREVIEW_PUBLIC_BASE_URL%/}" "${PREVIEW_PATH_PREFIX}" "${pr}"
+}
+
+preview_nginx_conf() {
+    local pr="${1:-}"
+    require_int "${pr}" "PR number"
+    printf '%s/%s%s.conf\n' "${PREVIEW_NGINX_DIR}" "${PREVIEW_PATH_PREFIX}" "${pr}"
+}
+
+# ---------------------------------------------------------------------------
+# nginx helpers
+# ---------------------------------------------------------------------------
+
+# Validates the whole nginx configuration before reloading, so a broken
+# preview snippet can never take down the site. Returns non-zero on failure
+# instead of exiting, so callers can roll back first.
+nginx_reload() {
+    if ! ${SUDO} nginx -t; then
+        log "nginx -t failed, not reloading"
+        return 1
+    fi
+    if ! ${SUDO} systemctl reload nginx; then
+        log "systemctl reload nginx failed"
+        return 1
+    fi
+    log "nginx reloaded"
+    return 0
+}
+
+# write_rtxcomplete_conf <port|"">
+# The ARAX UI loads /rtxcomplete/ with a root absolute path, so every preview
+# on the box has to share one autocomplete backend. We point it at whichever
+# preview was deployed most recently. An empty port removes the snippet.
+write_rtxcomplete_conf() {
+    local port="${1:-}"
+    if [ -z "${port}" ]; then
+        ${SUDO} rm -f "${PREVIEW_RTXCOMPLETE_CONF}"
+        log "removed shared ${PREVIEW_RTXCOMPLETE_CONF}"
+        return 0
+    fi
+    require_int "${port}" "port"
+    local pr_note="${2:-}"
+    ${SUDO} tee "${PREVIEW_RTXCOMPLETE_CONF}" >/dev/null <<RTXCOMPLETE_EOF
+# managed by deploy/preview/*.sh. The ARAX UI references /rtxcomplete/ root-absolute,
+# so all previews share the autocomplete service of the most recently deployed preview (PR ${pr_note}).
+location /rtxcomplete/ {
+    proxy_pass http://127.0.0.1:${port}/rtxcomplete/;
+    proxy_read_timeout 300s;
+    proxy_buffering off;
+    proxy_set_header Host \$host;
+}
+RTXCOMPLETE_EOF
+    log "wrote shared ${PREVIEW_RTXCOMPLETE_CONF} pointing at port ${port}"
+}
+
+# Reads the upstream port currently configured in the shared snippet, or
+# nothing if the snippet is absent.
+rtxcomplete_conf_port() {
+    # The trailing "|| true" matters: callers run with errexit and pipefail, and
+    # a missing snippet has to read as "no port", not as a fatal error.
+    ${SUDO} cat "${PREVIEW_RTXCOMPLETE_CONF}" 2>/dev/null \
+        | sed -n 's|^ *proxy_pass http://127\.0\.0\.1:\([0-9][0-9]*\)/rtxcomplete/;.*|\1|p' \
+        | head -n 1 || true
+}
+
+# ---------------------------------------------------------------------------
+# Container inventory
+# ---------------------------------------------------------------------------
+
+# All PR numbers that have a preview container, running or not.
+list_preview_prs() {
+    ${DOCKER} ps -a --filter 'label=arax.preview=true' \
+        --format '{{.Label "arax.preview.pr"}}' 2>/dev/null \
+        | grep -E '^[0-9]+$' || true
+}
+
+# Reads one label off a preview container. Prints nothing if absent.
+preview_label() {
+    local pr="${1:-}"
+    local key="${2:-}"
+    local container
+    container="$(preview_container "${pr}")"
+    ${DOCKER} inspect --format "{{index .Config.Labels \"${key}\"}}" "${container}" 2>/dev/null || true
+}
+
+# PR number of the running preview with the largest creation timestamp, or
+# nothing when no preview is running.
+newest_preview_pr() {
+    # As above: grep exits 1 when no preview is running, and with pipefail that
+    # would abort the caller instead of simply printing nothing.
+    ${DOCKER} ps --filter 'label=arax.preview=true' \
+        --format '{{.Label "arax.preview.created"}} {{.Label "arax.preview.pr"}}' 2>/dev/null \
+        | grep -E '^[0-9]+ [0-9]+$' \
+        | sort -k1,1n \
+        | tail -n 1 \
+        | awk '{print $2}' || true
+}

--- a/deploy/preview/smoke.sh
+++ b/deploy/preview/smoke.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# Smoke test one ARAX preview container. Everything is checked against the
+# loopback port on the host, not through nginx, so a failure here always means
+# the container itself is unhealthy.
+#
+# Usage: smoke.sh <PR> [--pytest "<pytest args>"]
+#
+# Prints a Markdown table on stdout, which the workflow pastes into the PR
+# comment. Exits non-zero when any check failed.
+#
+# Issue #2846.
+
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+usage() {
+    cat >&2 <<'USAGE_EOF'
+Usage: smoke.sh <PR> [--pytest "<pytest args>"]
+
+  PR        pull request number, for example 2853
+  --pytest  also run the ARAX test suite inside the container. The argument
+            may be an empty string, which runs the whole suite.
+USAGE_EOF
+    exit 2
+}
+
+[ "$#" -ge 1 ] || usage
+
+PR="$1"
+shift
+require_int "${PR}" "PR number"
+
+RUN_PYTEST="no"
+PYTEST_ARGS=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --pytest)
+            RUN_PYTEST="yes"
+            PYTEST_ARGS="${2:-}"
+            shift 2 || shift
+            ;;
+        *)
+            die "unknown argument '$1'"
+            ;;
+    esac
+done
+
+PORT="$(preview_port "${PR}")"
+CONTAINER="$(preview_container "${PR}")"
+BASE="http://127.0.0.1:${PORT}"
+
+ROWS=()
+FAILURES=0
+PYTEST_TAIL=""
+
+record() {
+    local name="$1"
+    local ok="$2"
+    local detail="$3"
+    if [ "${ok}" = "yes" ]; then
+        ROWS+=("| ${name} | pass | ${detail} |")
+    else
+        ROWS+=("| ${name} | FAIL | ${detail} |")
+        FAILURES=$(( FAILURES + 1 ))
+    fi
+}
+
+# Prints the HTTP status code, or 000 when the request never completed.
+http_code() {
+    local url="$1"
+    local timeout="$2"
+    curl -s -o /dev/null -w '%{http_code}' -m "${timeout}" "${url}" 2>/dev/null || printf '000'
+}
+
+log "smoke testing PR ${PR} at ${BASE}"
+
+# The container must exist at all before any HTTP check is meaningful.
+if ! ${DOCKER} inspect "${CONTAINER}" >/dev/null 2>&1; then
+    record "container ${CONTAINER} exists" "no" "not found"
+else
+    RUNNING="$(${DOCKER} inspect --format '{{.State.Running}}' "${CONTAINER}" 2>/dev/null || printf 'false')"
+    if [ "${RUNNING}" = "true" ]; then
+        record "container ${CONTAINER} running" "yes" "up"
+    else
+        record "container ${CONTAINER} running" "no" "state ${RUNNING}"
+    fi
+fi
+
+# 1. the ARAX status endpoint
+CODE="$(http_code "${BASE}/api/arax/v1.4/status" 30)"
+if [ "${CODE}" = "200" ]; then
+    record "GET /api/arax/v1.4/status" "yes" "HTTP ${CODE}"
+else
+    record "GET /api/arax/v1.4/status" "no" "HTTP ${CODE}"
+fi
+
+# 2. the UI index page, which apache serves from the checked out repository
+BODY_FILE="$(mktemp)"
+CODE="$(curl -s -o "${BODY_FILE}" -w '%{http_code}' -m 30 "${BASE}/" 2>/dev/null || printf '000')"
+if [ "${CODE}" = "200" ] && grep -q 'ARAX' "${BODY_FILE}"; then
+    record "GET / serves the ARAX UI" "yes" "HTTP ${CODE}, body contains ARAX"
+elif [ "${CODE}" = "200" ]; then
+    record "GET / serves the ARAX UI" "no" "HTTP ${CODE}, body does not contain ARAX"
+else
+    record "GET / serves the ARAX UI" "no" "HTTP ${CODE}"
+fi
+rm -f "${BODY_FILE}"
+
+# 3. the swagger UI. Connexion answers with a redirect on some versions, so
+# any 2xx or 3xx counts as a pass.
+CODE="$(http_code "${BASE}/api/arax/v1.4/ui/" 30)"
+case "${CODE}" in
+    200|30[0-9])
+        record "GET /api/arax/v1.4/ui/" "yes" "HTTP ${CODE}"
+        ;;
+    *)
+        record "GET /api/arax/v1.4/ui/" "no" "HTTP ${CODE}"
+        ;;
+esac
+
+# 4. the meta knowledge graph, which is the first endpoint that touches the
+# knowledge provider caches and is therefore slow on a cold container.
+CODE="$(http_code "${BASE}/api/arax/v1.4/meta_knowledge_graph" 180)"
+if [ "${CODE}" = "200" ]; then
+    record "GET /api/arax/v1.4/meta_knowledge_graph" "yes" "HTTP ${CODE}"
+else
+    record "GET /api/arax/v1.4/meta_knowledge_graph" "no" "HTTP ${CODE}"
+fi
+
+# 5. optional full test suite inside the container
+if [ "${RUN_PYTEST}" = "yes" ]; then
+    log "running pytest inside ${CONTAINER} with args '${PYTEST_ARGS}'"
+    PYTEST_LOG="$(mktemp)"
+    set +o errexit
+    ${DOCKER} exec "${CONTAINER}" bash -c "cd /mnt/data/orangeboard/production/RTX/code/ARAX/test && pytest -v --disable-pytest-warnings ${PYTEST_ARGS}" \
+        > "${PYTEST_LOG}" 2>&1
+    PYTEST_RC=$?
+    set -o errexit
+    cat "${PYTEST_LOG}" >&2
+    PYTEST_TAIL="$(tail -n 60 "${PYTEST_LOG}")"
+    rm -f "${PYTEST_LOG}"
+    if [ "${PYTEST_RC}" -eq 0 ]; then
+        record "pytest ${PYTEST_ARGS}" "yes" "exit 0"
+    else
+        record "pytest ${PYTEST_ARGS}" "no" "exit ${PYTEST_RC}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+render_report() {
+    printf '| check | result | detail |\n'
+    printf '| --- | --- | --- |\n'
+    local row
+    for row in "${ROWS[@]}"; do
+        printf '%s\n' "${row}"
+    done
+    if [ -n "${PYTEST_TAIL}" ]; then
+        printf '\n<details><summary>pytest output, last 60 lines</summary>\n\n'
+        # the backticks are a literal markdown fence, not a substitution
+        # shellcheck disable=SC2016
+        printf '```\n%s\n```\n\n' "${PYTEST_TAIL}"
+        printf '</details>\n'
+    fi
+}
+
+render_report
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    render_report >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+if [ "${FAILURES}" -gt 0 ]; then
+    log "${FAILURES} smoke check(s) failed for PR ${PR}"
+    exit 1
+fi
+log "all smoke checks passed for PR ${PR}"

--- a/deploy/preview/smoke.sh
+++ b/deploy/preview/smoke.sh
@@ -76,18 +76,53 @@ http_code() {
     curl -s -o /dev/null -w '%{http_code}' -m "${timeout}" "${url}" 2>/dev/null || printf '000'
 }
 
+render_report() {
+    printf '| check | result | detail |\n'
+    printf '| --- | --- | --- |\n'
+    local row
+    for row in "${ROWS[@]}"; do
+        printf '%s\n' "${row}"
+    done
+    if [ -n "${PYTEST_TAIL}" ]; then
+        printf '\n<details><summary>pytest output, last 60 lines</summary>\n\n'
+        # the backticks are a literal markdown fence, not a substitution
+        # shellcheck disable=SC2016
+        printf '```\n%s\n```\n\n' "${PYTEST_TAIL}"
+        printf '</details>\n'
+    fi
+}
+
+# Renders the table, mirrors it into the step summary and exits with the
+# number of failures as the verdict. Called at the end, and early when the
+# container is not even running.
+finish() {
+    render_report
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        render_report >> "${GITHUB_STEP_SUMMARY}"
+    fi
+    if [ "${FAILURES}" -gt 0 ]; then
+        log "${FAILURES} smoke check(s) failed for PR ${PR}"
+        exit 1
+    fi
+    log "all smoke checks passed for PR ${PR}"
+    exit 0
+}
+
 log "smoke testing PR ${PR} at ${BASE}"
 
-# The container must exist at all before any HTTP check is meaningful.
+# The container must exist and be running before any HTTP check is
+# meaningful. Short-circuit here rather than walking through four curl
+# checks with timeouts of up to 180 seconds against a dead port.
 if ! ${DOCKER} inspect "${CONTAINER}" >/dev/null 2>&1; then
-    record "container ${CONTAINER} exists" "no" "not found"
+    record "container ${CONTAINER} exists" "no" "not found, skipping every HTTP check"
+    finish
+fi
+RUNNING="$(${DOCKER} inspect --format '{{.State.Running}}' "${CONTAINER}" 2>/dev/null || printf 'false')"
+if [ "${RUNNING}" = "true" ]; then
+    record "container ${CONTAINER} running" "yes" "up"
 else
-    RUNNING="$(${DOCKER} inspect --format '{{.State.Running}}' "${CONTAINER}" 2>/dev/null || printf 'false')"
-    if [ "${RUNNING}" = "true" ]; then
-        record "container ${CONTAINER} running" "yes" "up"
-    else
-        record "container ${CONTAINER} running" "no" "state ${RUNNING}"
-    fi
+    record "container ${CONTAINER} running" "no" "state ${RUNNING}, skipping every HTTP check"
+    finish
 fi
 
 # 1. the ARAX status endpoint
@@ -154,30 +189,4 @@ fi
 # Report
 # ---------------------------------------------------------------------------
 
-render_report() {
-    printf '| check | result | detail |\n'
-    printf '| --- | --- | --- |\n'
-    local row
-    for row in "${ROWS[@]}"; do
-        printf '%s\n' "${row}"
-    done
-    if [ -n "${PYTEST_TAIL}" ]; then
-        printf '\n<details><summary>pytest output, last 60 lines</summary>\n\n'
-        # the backticks are a literal markdown fence, not a substitution
-        # shellcheck disable=SC2016
-        printf '```\n%s\n```\n\n' "${PYTEST_TAIL}"
-        printf '</details>\n'
-    fi
-}
-
-render_report
-
-if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-    render_report >> "${GITHUB_STEP_SUMMARY}"
-fi
-
-if [ "${FAILURES}" -gt 0 ]; then
-    log "${FAILURES} smoke check(s) failed for PR ${PR}"
-    exit 1
-fi
-log "all smoke checks passed for PR ${PR}"
+finish

--- a/deploy/preview/teardown.sh
+++ b/deploy/preview/teardown.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Remove one ARAX preview environment. Safe to run repeatedly and safe to run
+# for a PR that was never deployed.
+#
+# Usage: teardown.sh <PR>
+#
+# Issue #2846.
+
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+[ "$#" -ge 1 ] || { printf 'Usage: teardown.sh <PR>\n' >&2; exit 2; }
+
+PR="$1"
+require_int "${PR}" "PR number"
+
+PORT="$(preview_port "${PR}")"
+CONTAINER="$(preview_container "${PR}")"
+IMAGE="$(preview_image "${PR}")"
+NGINX_CONF="$(preview_nginx_conf "${PR}")"
+
+REMOVED=()
+
+log "tearing down the preview for PR ${PR}"
+
+if ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1; then
+    REMOVED+=("container ${CONTAINER}")
+else
+    log "no container ${CONTAINER}"
+fi
+
+if ${DOCKER} rmi -f "${IMAGE}" >/dev/null 2>&1; then
+    REMOVED+=("image ${IMAGE}")
+else
+    log "no image ${IMAGE}"
+fi
+
+NGINX_TOUCHED="no"
+if ${SUDO} test -d "${PREVIEW_NGINX_DIR}"; then
+    if ${SUDO} test -f "${NGINX_CONF}"; then
+        ${SUDO} rm -f "${NGINX_CONF}"
+        REMOVED+=("nginx snippet ${NGINX_CONF}")
+        NGINX_TOUCHED="yes"
+    else
+        log "no nginx snippet ${NGINX_CONF}"
+    fi
+
+    # The shared autocomplete snippet may still point at the preview we just
+    # deleted. The container is already gone, so newest_preview_pr cannot pick
+    # this PR again.
+    CURRENT_RTXCOMPLETE_PORT="$(rtxcomplete_conf_port)"
+    if [ "${CURRENT_RTXCOMPLETE_PORT}" = "${PORT}" ]; then
+        NEWEST="$(newest_preview_pr)"
+        if [ -n "${NEWEST}" ]; then
+            write_rtxcomplete_conf "$(preview_port "${NEWEST}")" "${NEWEST}"
+            REMOVED+=("repointed /rtxcomplete/ at PR ${NEWEST}")
+        else
+            write_rtxcomplete_conf ""
+            REMOVED+=("removed the shared /rtxcomplete/ snippet, no previews left")
+        fi
+        NGINX_TOUCHED="yes"
+    fi
+
+    if [ "${NGINX_TOUCHED}" = "yes" ]; then
+        nginx_reload || log "WARNING: nginx did not reload cleanly, inspect the host by hand"
+    fi
+else
+    log "WARNING: ${PREVIEW_NGINX_DIR} does not exist, skipping the nginx cleanup"
+fi
+
+if [ "${#REMOVED[@]}" -eq 0 ]; then
+    printf 'Nothing to remove for PR %s.\n' "${PR}"
+else
+    printf 'Removed for PR %s:\n' "${PR}"
+    for item in "${REMOVED[@]}"; do
+        printf '  - %s\n' "${item}"
+    done
+fi

--- a/deploy/preview/teardown.sh
+++ b/deploy/preview/teardown.sh
@@ -24,17 +24,34 @@ IMAGE="$(preview_image "${PR}")"
 NGINX_CONF="$(preview_nginx_conf "${PR}")"
 
 REMOVED=()
+FAILURES=0
 
 log "tearing down the preview for PR ${PR}"
 
-if ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1; then
-    REMOVED+=("container ${CONTAINER}")
+# docker rm -f and docker rmi -f exit 0 even when the target does not exist
+# (verified on Docker 20.10.21), so their exit status cannot tell "removed"
+# from "was never there". Check existence explicitly before and after, and
+# treat "still there afterwards" as a failure the caller must hear about.
+if ${DOCKER} inspect --type container "${CONTAINER}" >/dev/null 2>&1; then
+    if ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 \
+        && ! ${DOCKER} inspect --type container "${CONTAINER}" >/dev/null 2>&1; then
+        REMOVED+=("container ${CONTAINER}")
+    else
+        log "WARNING: could not remove container ${CONTAINER}"
+        FAILURES=$(( FAILURES + 1 ))
+    fi
 else
     log "no container ${CONTAINER}"
 fi
 
-if ${DOCKER} rmi -f "${IMAGE}" >/dev/null 2>&1; then
-    REMOVED+=("image ${IMAGE}")
+if ${DOCKER} inspect --type image "${IMAGE}" >/dev/null 2>&1; then
+    if ${DOCKER} rmi -f "${IMAGE}" >/dev/null 2>&1 \
+        && ! ${DOCKER} inspect --type image "${IMAGE}" >/dev/null 2>&1; then
+        REMOVED+=("image ${IMAGE}")
+    else
+        log "WARNING: could not remove image ${IMAGE}"
+        FAILURES=$(( FAILURES + 1 ))
+    fi
 else
     log "no image ${IMAGE}"
 fi
@@ -72,11 +89,15 @@ else
     log "WARNING: ${PREVIEW_NGINX_DIR} does not exist, skipping the nginx cleanup"
 fi
 
-if [ "${#REMOVED[@]}" -eq 0 ]; then
-    printf 'Nothing to remove for PR %s.\n' "${PR}"
-else
+if [ "${#REMOVED[@]}" -gt 0 ]; then
     printf 'Removed for PR %s:\n' "${PR}"
     for item in "${REMOVED[@]}"; do
         printf '  - %s\n' "${item}"
     done
+elif [ "${FAILURES}" -eq 0 ]; then
+    printf 'Nothing to remove for PR %s.\n' "${PR}"
 fi
+
+# A non-zero exit tells gc.sh and the workflow that something is still on the
+# host, so neither of them can report a clean teardown that did not happen.
+[ "${FAILURES}" -eq 0 ] || die "teardown of PR ${PR} left ${FAILURES} resource(s) behind"


### PR DESCRIPTION
This pull request introduces a new workflow for per-PR ARAX preview environments and refines the Docker cleanup steps in the existing `pytest.yml` workflow to avoid interfering with other containers, such as those used for previews. The changes also add concurrency controls to prevent overlapping CI runs.

**New ARAX Preview Deployment Workflow:**

* Added `.github/workflows/deploy-preview.yml` to automate deploying, testing, and tearing down per-PR ARAX preview environments using Docker containers on self-hosted runners. This workflow supports triggers for manual dispatch, PR comments, PR closure, and scheduled garbage collection, with detailed status comments posted back to the PR.

**Improvements to `pytest.yml` Workflow:**

* Added concurrency control to the workflow to ensure only one instance runs per branch and cancels any in-progress runs if a new one is started.
* Refined Docker cleanup steps to only remove the `rtx_test` container and `rtx:test` image, preventing accidental removal of other containers or images (such as preview containers) on the host. 