### PR TITLE
one push preview deploy of CI on cicd.rtx.ai continiued

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -120,8 +120,13 @@ jobs:
             if (context.eventName === 'workflow_dispatch') {
               const requested = context.payload.inputs && context.payload.inputs.force_rebuild;
               force = requested === true || String(requested).toLowerCase() === 'true';
+              // An absent input keeps the declared default of true. Only an
+              // explicit value overrides it, so a dispatch payload without
+              // run_tests does not silently skip the suite (Copilot review).
               const requestedTests = context.payload.inputs && context.payload.inputs.run_tests;
-              runTests = requestedTests === true || String(requestedTests).toLowerCase() === 'true';
+              if (requestedTests !== undefined && requestedTests !== null && requestedTests !== '') {
+                runTests = requestedTests === true || String(requestedTests).toLowerCase() === 'true';
+              }
             } else if (context.eventName === 'issue_comment') {
               const body = (context.payload.comment && context.payload.comment.body) || '';
               // Only the first line carries flags, so "/deploy" followed by a

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ""
+      force_rebuild:
+        description: "Always rebuild the image even when a fast redeploy is possible"
+        required: false
+        type: boolean
+        default: false
   issue_comment:
     types: [created]
   pull_request:
@@ -105,10 +110,27 @@ jobs:
               return;
             }
 
+            // deploy.sh picks a fast redeploy on its own. --force is how a human
+            // says "rebuild the image anyway", either as /deploy --force on the
+            // pull request or as the force_rebuild input on Run workflow.
+            let force = false;
+            if (context.eventName === 'workflow_dispatch') {
+              const requested = context.payload.inputs && context.payload.inputs.force_rebuild;
+              force = requested === true || String(requested).toLowerCase() === 'true';
+            } else if (context.eventName === 'issue_comment') {
+              const body = (context.payload.comment && context.payload.comment.body) || '';
+              // Only the first line carries flags, so "/deploy" followed by a
+              // paragraph mentioning --force does not count.
+              const firstLine = body.split(/\r?\n/)[0].trim();
+              const flags = firstLine.match(/^\/deploy(\s.*)?$/);
+              force = flags !== null && / --force(\s|$)/.test(flags[1] || '');
+            }
+
             core.setOutput('pr', String(prNumber));
             core.setOutput('branch', data.head.ref);
             core.setOutput('sha', data.head.sha);
             core.setOutput('html_url', data.html_url);
+            core.setOutput('force', force ? 'true' : 'false');
 
             // Acknowledge the /deploy comment so the author knows it was picked up.
             if (context.eventName === 'issue_comment') {
@@ -145,10 +167,15 @@ jobs:
           PR: ${{ steps.resolve.outputs.pr }}
           BRANCH: ${{ steps.resolve.outputs.branch }}
           SHA: ${{ steps.resolve.outputs.sha }}
+          FORCE: ${{ steps.resolve.outputs.force }}
           PREVIEW_BUILD_CONTEXT: ${{ github.workspace }}/pr-head/DockerBuild
         run: |
           set -o pipefail
-          bash deploy/preview/deploy.sh "$PR" "$BRANCH" "$SHA" 2>&1 | tee preview-deploy.log
+          if [ "$FORCE" = "true" ]; then
+            bash deploy/preview/deploy.sh --force "$PR" "$BRANCH" "$SHA" 2>&1 | tee preview-deploy.log
+          else
+            bash deploy/preview/deploy.sh "$PR" "$BRANCH" "$SHA" 2>&1 | tee preview-deploy.log
+          fi
 
       - name: Smoke test
         id: smoke
@@ -188,6 +215,8 @@ jobs:
           PR_BRANCH: ${{ steps.resolve.outputs.branch }}
           PR_SHA: ${{ steps.resolve.outputs.sha }}
           PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          DEPLOY_MODE: ${{ steps.deploy.outputs.mode }}
+          DEPLOY_REASON: ${{ steps.deploy.outputs.reason }}
           DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
           SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -235,13 +264,23 @@ jobs:
             lines.push('');
             lines.push('**Build:** `' + branch + '` @ `' + shortSha + '`');
             lines.push('');
+            const mode = process.env.DEPLOY_MODE || '';
+            const reason = process.env.DEPLOY_REASON || '';
+            if (mode === 'fast') {
+              lines.push('**Deploy:** fast redeploy');
+            } else if (mode === 'full') {
+              lines.push('**Deploy:** full rebuild' + (reason ? ' (' + reason + ')' : ''));
+            } else {
+              lines.push('**Deploy:** unknown');
+            }
+            lines.push('');
             lines.push('### Smoke test');
             lines.push('');
             lines.push(smokeTable);
             lines.push('');
             lines.push('[Workflow run](' + runUrl + ')');
             lines.push('');
-            lines.push('Comment `/deploy` to redeploy, `/undeploy` to remove. Previews are garbage-collected after ' + ttl + ' days or when the PR closes.');
+            lines.push('Comment `/deploy` to redeploy, `/deploy --force` to rebuild the image, `/undeploy` to remove. Previews are garbage-collected after ' + ttl + ' days or when the PR closes.');
             const body = lines.join('\n');
 
             const existing = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -17,10 +17,10 @@ on:
         required: true
         type: string
       run_tests:
-        description: "Run pytest inside the preview container after deploy"
+        description: "Run the pytest suite inside the preview container after deploy"
         required: false
         type: boolean
-        default: false
+        default: true
       pytest_args:
         description: "Extra pytest args (for example -k test_ARAX_query)"
         required: false
@@ -113,10 +113,15 @@ jobs:
             // deploy.sh picks a fast redeploy on its own. --force is how a human
             // says "rebuild the image anyway", either as /deploy --force on the
             // pull request or as the force_rebuild input on Run workflow.
+            // The test suite runs by default. --no-tests on the /deploy line, or
+            // clearing the run_tests input on Run workflow, turns it off.
             let force = false;
+            let runTests = true;
             if (context.eventName === 'workflow_dispatch') {
               const requested = context.payload.inputs && context.payload.inputs.force_rebuild;
               force = requested === true || String(requested).toLowerCase() === 'true';
+              const requestedTests = context.payload.inputs && context.payload.inputs.run_tests;
+              runTests = requestedTests === true || String(requestedTests).toLowerCase() === 'true';
             } else if (context.eventName === 'issue_comment') {
               const body = (context.payload.comment && context.payload.comment.body) || '';
               // Only the first line carries flags, so "/deploy" followed by a
@@ -124,6 +129,7 @@ jobs:
               const firstLine = body.split(/\r?\n/)[0].trim();
               const flags = firstLine.match(/^\/deploy(\s.*)?$/);
               force = flags !== null && / --force(\s|$)/.test(flags[1] || '');
+              runTests = !(flags !== null && / --no-tests(\s|$)/.test(flags[1] || ''));
             }
 
             core.setOutput('pr', String(prNumber));
@@ -131,6 +137,7 @@ jobs:
             core.setOutput('sha', data.head.sha);
             core.setOutput('html_url', data.html_url);
             core.setOutput('force', force ? 'true' : 'false');
+            core.setOutput('run_tests', runTests ? 'true' : 'false');
 
             // Acknowledge the /deploy comment so the author knows it was picked up.
             if (context.eventName === 'issue_comment') {
@@ -177,31 +184,16 @@ jobs:
             bash deploy/preview/deploy.sh "$PR" "$BRANCH" "$SHA" 2>&1 | tee preview-deploy.log
           fi
 
+      # The four HTTP checks only. The test suite is its own step below, so
+      # that it can have its own timeout and its own comment.
       - name: Smoke test
         id: smoke
         continue-on-error: true
         env:
           PR: ${{ steps.resolve.outputs.pr }}
-          RUN_TESTS: ${{ github.event.inputs.run_tests || 'false' }}
-          PYTEST_ARGS: ${{ github.event.inputs.pytest_args || '' }}
         run: |
           set -o pipefail
-          if [ "$RUN_TESTS" = "true" ]; then
-            bash deploy/preview/smoke.sh "$PR" --pytest "$PYTEST_ARGS" 2>&1 | tee preview-smoke.log
-          else
-            bash deploy/preview/smoke.sh "$PR" 2>&1 | tee preview-smoke.log
-          fi
-
-      - name: Upload logs
-        if: always()
-        uses: RTXteam/upload-artifact@v4
-        with:
-          name: preview-pr-${{ steps.resolve.outputs.pr }}-logs
-          path: |
-            preview-deploy.log
-            preview-smoke.log
-          retention-days: 14
-          if-no-files-found: warn
+          bash deploy/preview/smoke.sh "$PR" 2>&1 | tee preview-smoke.log
 
       # Values that originate outside this file (branch names above all) are
       # handed to the script through env, never spliced into the JavaScript
@@ -218,6 +210,7 @@ jobs:
           DEPLOY_MODE: ${{ steps.deploy.outputs.mode }}
           DEPLOY_REASON: ${{ steps.deploy.outputs.reason }}
           DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+          DEPLOY_REFUSED: ${{ steps.deploy.outputs.refused }}
           SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
@@ -233,6 +226,9 @@ jobs:
             const deployOutcome = process.env.DEPLOY_OUTCOME;
             const smokeOutcome = process.env.SMOKE_OUTCOME;
             const ok = deployOutcome === 'success' && smokeOutcome === 'success';
+            // A preflight refusal is not a broken deploy, it is the host saying
+            // it has no room. Say which limit was hit instead of "failed".
+            const refused = deployOutcome !== 'success' ? (process.env.DEPLOY_REFUSED || '') : '';
 
             let smokeTable = '_No smoke test output was produced._';
             try {
@@ -254,7 +250,13 @@ jobs:
             lines.push(marker);
             lines.push('## ARAX preview');
             lines.push('');
-            lines.push(ok ? '✅ deployed' : '❌ failed');
+            if (ok) {
+              lines.push('✅ deployed');
+            } else if (refused) {
+              lines.push('❌ refused: ' + refused);
+            } else {
+              lines.push('❌ failed');
+            }
             lines.push('');
             if (url) {
               lines.push('**URL:** ' + url);
@@ -316,8 +318,204 @@ jobs:
               }
             }
 
-      # The smoke step is continue-on-error so that the comment above always
-      # runs. The job still has to go red when anything failed.
+      # Comment two. The suite takes about two and a half minutes on a healthy
+      # preview and is informational, so it never fails the job.
+      - name: Pytest suite
+        id: pytest
+        if: steps.resolve.outputs.run_tests == 'true' && steps.deploy.outcome == 'success'
+        continue-on-error: true
+        timeout-minutes: 45
+        env:
+          PR: ${{ steps.resolve.outputs.pr }}
+          PYTEST_ARGS: ${{ github.event.inputs.pytest_args || '' }}
+        run: |
+          set -o pipefail
+          bash deploy/preview/pytest_report.sh "$PR" "$PYTEST_ARGS" 2>&1 | tee preview-pytest.log
+
+      - name: Comment pytest results
+        if: always() && steps.resolve.outputs.run_tests == 'true' && steps.deploy.outcome == 'success'
+        uses: RTXteam/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr }}
+          PR_BRANCH: ${{ steps.resolve.outputs.branch }}
+          PR_SHA: ${{ steps.resolve.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- arax-preview-pytest -->';
+            const pr = Number(process.env.PR_NUMBER);
+            if (!pr) {
+              core.info('no PR was resolved, nothing to comment on');
+              return;
+            }
+
+            // The log holds the raw pytest output first and the report last,
+            // so the report starts at the first summary line.
+            let report = '_The pytest step produced no output._';
+            try {
+              const raw = fs.readFileSync('preview-pytest.log', 'utf8');
+              const start = raw.indexOf('**pytest:**');
+              report = start >= 0 ? raw.slice(start).trim() : raw.trim();
+            } catch (error) {
+              core.info('preview-pytest.log is missing: ' + error.message);
+            }
+            if (report.length > 60000) {
+              report = report.slice(0, 60000) + '\n\n_Truncated. The whole log is in the run artifact._';
+            }
+
+            const branch = process.env.PR_BRANCH || 'unknown';
+            const sha = process.env.PR_SHA || '';
+            const shortSha = sha ? sha.slice(0, 7) : 'unknown';
+
+            const lines = [];
+            lines.push(marker);
+            lines.push('## Preview pytest');
+            lines.push('');
+            lines.push('**Build:** `' + branch + '` @ `' + shortSha + '`');
+            lines.push('');
+            lines.push(report);
+            lines.push('');
+            lines.push('[Workflow run](' + process.env.RUN_URL + ')');
+            const body = lines.join('\n');
+
+            // Same chronology as the status comment: a new comment every run,
+            // older ones with this marker collapsed as outdated.
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              per_page: 100,
+            });
+            const outdated = existing.filter(function (comment) {
+              return comment.body && comment.body.includes(marker);
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: body,
+            });
+
+            for (const old of outdated) {
+              try {
+                await github.graphql(
+                  'mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }',
+                  { id: old.node_id }
+                );
+              } catch (error) {
+                core.info('could not minimize comment ' + old.id + ': ' + error.message);
+              }
+            }
+
+      # Comment three. The four example queries of the UI, posted through the
+      # public URL so that nginx and apache are on the path as well. The
+      # payloads come from the pull request's own copy of rtx.js.
+      - name: Live query smoke
+        id: queries
+        if: steps.deploy.outcome == 'success'
+        continue-on-error: true
+        timeout-minutes: 30
+        env:
+          PR: ${{ steps.resolve.outputs.pr }}
+          PREVIEW_UI_RTXJS: ${{ github.workspace }}/pr-head/code/UI/interactive/rtx.js
+        run: |
+          set -o pipefail
+          bash deploy/preview/query_smoke.sh "$PR" 2>&1 | tee preview-queries.log
+
+      - name: Comment query results
+        if: always() && steps.deploy.outcome == 'success'
+        uses: RTXteam/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr }}
+          PR_BRANCH: ${{ steps.resolve.outputs.branch }}
+          PR_SHA: ${{ steps.resolve.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- arax-preview-queries -->';
+            const pr = Number(process.env.PR_NUMBER);
+            if (!pr) {
+              core.info('no PR was resolved, nothing to comment on');
+              return;
+            }
+
+            let report = '_The live query step produced no output._';
+            try {
+              const raw = fs.readFileSync('preview-queries.log', 'utf8');
+              const start = raw.indexOf('| query |');
+              report = start >= 0 ? raw.slice(start).trim() : raw.trim();
+            } catch (error) {
+              core.info('preview-queries.log is missing: ' + error.message);
+            }
+            if (report.length > 60000) {
+              report = report.slice(0, 60000) + '\n\n_Truncated. The whole log is in the run artifact._';
+            }
+
+            const branch = process.env.PR_BRANCH || 'unknown';
+            const sha = process.env.PR_SHA || '';
+            const shortSha = sha ? sha.slice(0, 7) : 'unknown';
+
+            const lines = [];
+            lines.push(marker);
+            lines.push('## Preview live queries');
+            lines.push('');
+            lines.push('**Build:** `' + branch + '` @ `' + shortSha + '`');
+            lines.push('');
+            lines.push(report);
+            lines.push('');
+            lines.push('[Workflow run](' + process.env.RUN_URL + ')');
+            const body = lines.join('\n');
+
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              per_page: 100,
+            });
+            const outdated = existing.filter(function (comment) {
+              return comment.body && comment.body.includes(marker);
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: body,
+            });
+
+            for (const old of outdated) {
+              try {
+                await github.graphql(
+                  'mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }',
+                  { id: old.node_id }
+                );
+              } catch (error) {
+                core.info('could not minimize comment ' + old.id + ': ' + error.message);
+              }
+            }
+
+      # Last, so that every log this job produces is in the artifact.
+      - name: Upload logs
+        if: always()
+        uses: RTXteam/upload-artifact@v4
+        with:
+          name: preview-pr-${{ steps.resolve.outputs.pr }}-logs
+          path: |
+            preview-deploy.log
+            preview-smoke.log
+            preview-pytest.log
+            preview-queries.log
+          retention-days: 14
+          if-no-files-found: warn
+
+      # The smoke step is continue-on-error so that the comments above always
+      # run. The job still has to go red when the deploy or the smoke test
+      # failed. The pytest and live query steps are deliberately not in this
+      # condition: they are informational, and a preview that is up and
+      # answering is still useful when one test is red.
       - name: Fail the job when deploy or smoke failed
         if: steps.deploy.outcome == 'failure' || steps.smoke.outcome == 'failure'
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -283,30 +283,37 @@ jobs:
             lines.push('Comment `/deploy` to redeploy, `/deploy --force` to rebuild the image, `/undeploy` to remove. Previews are garbage-collected after ' + ttl + ' days or when the PR closes.');
             const body = lines.join('\n');
 
+            // Chronology over stickiness: every event posts a NEW comment so
+            // the thread reads in order, and older status comments get
+            // collapsed as outdated so the thread does not fill with bot
+            // noise. Minimizing is best effort, a missing permission must not
+            // fail the job.
             const existing = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr,
               per_page: 100,
             });
-            const mine = existing.find(function (comment) {
+            const outdated = existing.filter(function (comment) {
               return comment.body && comment.body.includes(marker);
             });
 
-            if (mine) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: mine.id,
-                body: body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr,
-                body: body,
-              });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: body,
+            });
+
+            for (const old of outdated) {
+              try {
+                await github.graphql(
+                  'mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }',
+                  { id: old.node_id }
+                );
+              } catch (error) {
+                core.info('could not minimize comment ' + old.id + ': ' + error.message);
+              }
             }
 
       # The smoke step is continue-on-error so that the comment above always
@@ -377,30 +384,37 @@ jobs:
                 'See the [workflow run](' + runUrl + ') and clean up with ' +
                 '`bash deploy/preview/teardown.sh ' + pr + '` on cicd.rtx.ai.';
 
+            // Chronology over stickiness: every event posts a NEW comment so
+            // the thread reads in order, and older status comments get
+            // collapsed as outdated so the thread does not fill with bot
+            // noise. Minimizing is best effort, a missing permission must not
+            // fail the job.
             const existing = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr,
               per_page: 100,
             });
-            const mine = existing.find(function (comment) {
+            const outdated = existing.filter(function (comment) {
               return comment.body && comment.body.includes(marker);
             });
 
-            if (mine) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: mine.id,
-                body: body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr,
-                body: body,
-              });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: body,
+            });
+
+            for (const old of outdated) {
+              try {
+                await github.graphql(
+                  'mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }',
+                  { id: old.node_id }
+                );
+              } catch (error) {
+                core.info('could not minimize comment ' + old.id + ': ' + error.message);
+              }
             }
 
   gc:

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -39,9 +39,10 @@ Three ways, all of which end up running the same scripts on the runner.
 - On the host directly: `bash deploy/preview/deploy.sh 2853 my-branch`. Pass the head commit as a
   third argument to make a fast redeploy possible, and `--force` to rule one out.
 
-The workflow posts one sticky comment on the pull request with the URL, the branch and short
-commit, whether the deploy was a fast redeploy or a full rebuild, and the smoke test table.
-Redeploying updates that same comment instead of adding a new one. A refused `/deploy` (fork pull
+The workflow posts a status comment on the pull request with the URL, the branch and short
+commit, whether the deploy was a fast redeploy or a full rebuild, and the smoke test table. Every
+deploy and teardown posts a new comment so the thread stays chronological, and the previous status
+comment is collapsed as outdated so the thread does not fill up. A refused `/deploy` (fork pull
 request, closed pull request) gets a short reply saying why.
 
 The scripts always run from the workflow's own branch on master, never from the pull

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -31,19 +31,31 @@ renames the snippet to `pr-2853.conf`. The port and the container name do not ch
 Three ways, all of which end up running the same scripts on the runner.
 
 - Comment `/deploy` on the pull request. Comment `/undeploy` to remove it again. Only comments
-  from an OWNER, MEMBER or COLLABORATOR are acted on. `/deploy --force` skips the fast redeploy
-  described below and always rebuilds the image.
-- Actions tab, pick **Preview Deploy**, **Run workflow**, fill in `pr_number`. Tick `run_tests`
-  to also run the ARAX test suite inside the container, and put anything extra in `pytest_args`.
-  Tick `force_rebuild` for the same effect as `/deploy --force`.
+  from an OWNER, MEMBER or COLLABORATOR are acted on. Two flags are read off the first line of
+  the comment:
+  - `--force` skips the fast redeploy described below and always rebuilds the image.
+  - `--no-tests` skips the pytest suite. The suite runs by default.
+- Actions tab, pick **Preview Deploy**, **Run workflow**, fill in `pr_number`. `run_tests` is
+  ticked by default and runs the ARAX test suite inside the container, `pytest_args` narrows it
+  down, and `force_rebuild` does what `/deploy --force` does.
 - On the host directly: `bash deploy/preview/deploy.sh 2853 my-branch`. Pass the head commit as a
   third argument to make a fast redeploy possible, and `--force` to rule one out.
 
-The workflow posts a status comment on the pull request with the URL, the branch and short
-commit, whether the deploy was a fast redeploy or a full rebuild, and the smoke test table. Every
-deploy and teardown posts a new comment so the thread stays chronological, and the previous status
-comment is collapsed as outdated so the thread does not fill up. A refused `/deploy` (fork pull
-request, closed pull request) gets a short reply saying why.
+### The three comments
+
+One deploy posts up to three comments, in this order.
+
+| comment | marker | what is in it | can it fail the job |
+| --- | --- | --- | --- |
+| **ARAX preview** | `arax-preview-status` | the URL, the branch and short commit, fast redeploy or full rebuild with the reason, and the smoke test table | yes, through the deploy and smoke steps |
+| **Preview pytest** | `arax-preview-pytest` | one summary line of passed, failed and skipped counts, and an expander with the failing test names and the last 80 lines when something failed | no |
+| **Preview live queries** | `arax-preview-queries` | a table of the four example queries of the UI with HTTP code, wall seconds, result count and knowledge graph size | no |
+
+Every event posts a new comment so the thread reads in order, and the previous comment with the
+same marker is collapsed as outdated so the thread does not fill up. The pytest and live query
+comments are informational: they report what happened and never turn the job red, because a
+preview that is up and answering is still useful when one test is broken. A refused `/deploy`
+(fork pull request, closed pull request, no room on the host) gets a short reply saying why.
 
 The scripts always run from the workflow's own branch on master, never from the pull
 request. The pull request head is checked out
@@ -77,12 +89,14 @@ the shorter path described in the next section.
   | cicd.rtx.ai                                                 |
   |                                                             |
   |  deploy.sh                                                  |
+  |    preflight: previews on the box, disk, memory, port       |
   |    docker build -f DockerBuild/CICD-Dockerfile              |
   |      (the image git clones RTXteam/RTX and checks out       |
   |       BUILD_BRANCH, so the branch must live upstream)       |
   |         |                                                   |
   |         v                                                   |
   |    docker run -d -i -t --name rtx_pr_2853                   |
+  |      --memory 2g --cpus 1.5                                 |
   |      -p 127.0.0.1:12853:80                                  |
   |      -v databases  -v config_secrets.json                   |
   |         |                                                   |
@@ -99,6 +113,7 @@ the shorter path described in the next section.
   |         |                                                   |
   |         v                                                   |
   |    poll http://127.0.0.1:12853/api/arax/v1.4/status         |
+  |    write /var/www/arax-preview/index.html                   |
   |                                                             |
   |  nginx :443  server_name cicd.rtx.ai                        |
   |    include /etc/nginx/arax-preview.d/*.conf;                |
@@ -149,6 +164,71 @@ in the log, in the summary and in the sticky pull request comment. A fast redepl
 health check stops there rather than rebuilding behind your back, and tells you to rerun with
 `--force`.
 
+## Resource guards
+
+The box is an `m5a.large` with 2 vCPUs, 7.5 GB of memory and no swap, and it also runs the pytest
+workflow. Every full deploy therefore has to get past a preflight before the image build starts,
+and every container is capped once it runs.
+
+| guard | default | why this number |
+| --- | --- | --- |
+| `PREVIEW_MEMORY_LIMIT` | `2g` | a preview idles at about 400 MB and was measured at 1889 MiB peak while answering queries. Never set this lower than `2g`, the kernel would kill the container in the middle of a query |
+| `PREVIEW_CPU_LIMIT` | `1.5` | a pathfinder query saturates both vCPUs for about 90 seconds. Half a core stays for nginx and the runner |
+| `PREVIEW_MAX_ACTIVE` | `3` | three previews at 2 GB each still leave room for the pytest workflow on a 7.5 GB box |
+| `PREVIEW_MIN_FREE_DISK_GB` | `10` | one preview image is about 3.94 GB and the build needs room for its layers |
+| `PREVIEW_MIN_FREE_RAM_MB` | `2048` | enough for the container that is about to start |
+
+The preflight runs on the full rebuild path only, after the previous container and image for this
+pull request are removed. A fast redeploy reuses a container that is already running and asks the
+host for nothing new, so none of it applies there. The checks are, in order:
+
+1. **How many other previews are on the box.** A redeploy of a pull request that already has a
+   container is not a new preview and never counts against the cap.
+2. **Free space** on the docker root, `/var/lib/docker`, falling back to `/`.
+3. **Available memory**, the available column of `free -m` rather than the free one, because page
+   cache is reclaimable.
+4. **The port**, which must be free now that this pull request's old container is gone. Anything
+   still listening belongs to something else, and `docker run` would only discover that several
+   minutes later, after the build.
+
+A refusal names the limit that was hit and what to do about it, and the pull request comment says
+`❌ refused` with that reason instead of the generic failure text. Comment `/undeploy` on a
+preview somebody is done with, or run `bash deploy/preview/gc.sh` on the host.
+
+## Status page
+
+`https://cicd.rtx.ai/previews/` lists every preview on the box. The bare root of `cicd.rtx.ai`
+redirects there, which replaces the stock **Welcome to nginx** page. `/cicd.txt` and
+`/.well-known/` are unaffected, because the redirect is an exact match on `/` only.
+
+Each preview gets a card with the pull request number linked to GitHub, the branch, the short
+commit linked to the commit, when the container was created, whether it is running, and a link to
+the preview. The dot next to the pull request number is live: the page asks each preview for its
+`/api/arax/v1.4/status` when it loads and turns green or red. With JavaScript off the dots stay
+grey and everything else still renders.
+
+Under each card are expanders with whatever reports exist for that pull request, embedded at
+generation time rather than fetched by the browser:
+
+| file | written by | what it holds |
+| --- | --- | --- |
+| `deploy-log.txt` | `deploy.sh` | the last 200 lines of the deploy, with every line that mentions a password, token, secret or authorization dropped |
+| `smoke.md` | `smoke.sh` | the smoke test table |
+| `pytest.md` | `pytest_report.sh` | the pytest summary |
+| `queries.md` | `query_smoke.sh` | the live query table |
+
+Those files live in `${PREVIEW_WEB_ROOT}/data/<PR>/`, which is `/var/www/arax-preview/data/<PR>/`
+by default, and they are removed with the preview. The full deploy logs live in
+`${PREVIEW_LOG_DIR}`, `/var/log/arax-preview` by default, one file per deploy run named
+`pr<PR>-<timestamp>.log`. Those outlive the preview on purpose, so a preview that is already gone
+can still be looked at, and garbage collection deletes them after 30 days.
+
+The page is rewritten on every deploy, on every teardown and by the nightly garbage collection,
+so it can be up to a day behind a container that died on its own. Writing it is best effort
+throughout and can never fail a deploy or a teardown. `install-nginx-include.sh` creates the
+document root, the log directory and the nginx snippet, and writes the empty state page, so
+`/previews/` answers before the first preview is ever deployed.
+
 ## One-time host setup
 
 Run this once on `cicd.rtx.ai`, as a human with sudo:
@@ -166,9 +246,24 @@ one line inside the certbot managed TLS server block for `cicd.rtx.ai`:
     include /etc/nginx/arax-preview.d/*.conf;
 ```
 
-Then it runs `nginx -t` and reloads. If the check fails the backup is restored. If no matching
-server block is found nothing is written and the script prints the manual instructions. Running
-it a second time detects the existing line and exits without touching anything.
+It also creates `/var/www/arax-preview/` and `/var/log/arax-preview/`, and writes
+`/etc/nginx/arax-preview.d/_previews.conf`, which serves the status page and redirects the bare
+root to it:
+
+```
+location = / { return 302 /previews/; }
+location /previews/ {
+    alias /var/www/arax-preview/;
+    index index.html;
+    default_type text/html;
+}
+```
+
+Then it runs `nginx -t` and reloads. If the check fails the backup is restored and a snippet this
+run wrote is removed again. If no matching server block is found nothing is written and the script
+prints the manual instructions. Running it a second time detects the existing include line and
+exits, after making sure the status page pieces are in place, and it only reloads nginx when it
+had to write the snippet.
 
 The runner user needs passwordless sudo for `docker`, `nginx`, `systemctl reload nginx`, `tee`,
 `rm` and `mkdir`. This is already true on `cicd.rtx.ai`, because `.github/workflows/pytest.yml`
@@ -193,6 +288,15 @@ Everything below is read by `deploy/preview/lib.sh` and can be overridden in the
 | `PREVIEW_BUILD_CONTEXT` | `<repo>/DockerBuild` | docker build context, the workflow points it at `pr-head/DockerBuild` |
 | `PREVIEW_DOCKERFILE` | `$PREVIEW_BUILD_CONTEXT/CICD-Dockerfile` | Dockerfile used for the image |
 | `PREVIEW_NGINX_SITE` | `/etc/nginx/sites-enabled/default` | site file edited by `install-nginx-include.sh` |
+| `PREVIEW_MEMORY_LIMIT` | `2g` | `docker run --memory` for a preview container. Never lower than `2g` |
+| `PREVIEW_CPU_LIMIT` | `1.5` | `docker run --cpus` for a preview container |
+| `PREVIEW_MAX_ACTIVE` | `3` | how many previews may live on the host at once |
+| `PREVIEW_MIN_FREE_DISK_GB` | `10` | refuse a full rebuild below this much free space on the docker root |
+| `PREVIEW_MIN_FREE_RAM_MB` | `2048` | refuse a full rebuild below this much available memory |
+| `PREVIEW_WEB_ROOT` | `/var/www/arax-preview` | document root of the status page, per-PR reports go in `data/<PR>/` |
+| `PREVIEW_LOG_DIR` | `/var/log/arax-preview` | full deploy logs, pruned after 30 days by `gc.sh` |
+| `PREVIEW_UI_RTXJS` | `<repo>/code/UI/interactive/rtx.js` | UI source `query_smoke.sh` reads the example payloads from |
+| `PREVIEW_QUERY_BASE` | the public preview URL | base URL `query_smoke.sh` posts to |
 | `DOCKER` | `sudo docker` | docker command used by every script |
 | `SUDO` | `sudo` | privilege escalation command used by every script |
 
@@ -242,6 +346,23 @@ bash deploy/preview/gc.sh --dry-run
 bash deploy/preview/smoke.sh 2853
 bash deploy/preview/smoke.sh 2853 --pytest "-k test_ARAX_query"
 
+# run the test suite and print the Markdown report the bot posts
+bash deploy/preview/pytest_report.sh 2853
+bash deploy/preview/pytest_report.sh 2853 "-k test_ARAX_query"
+
+# post the four example queries of the UI at a preview, through its public URL
+bash deploy/preview/query_smoke.sh 2853
+
+# the same, against a preview reached some other way
+PREVIEW_QUERY_BASE=http://127.0.0.1:12853 bash deploy/preview/query_smoke.sh 2853
+
+# rewrite the status page by hand
+bash -c '. deploy/preview/lib.sh; write_status_page'
+
+# what a preview left on the host
+ls /var/www/arax-preview/data/2853/     # the reports the status page embeds
+ls /var/log/arax-preview/               # full deploy logs, pruned after 30 days
+
 # list every preview on the box
 sudo docker ps --filter label=arax.preview=true
 
@@ -256,8 +377,9 @@ sudo bash deploy/preview/install-nginx-include.sh
   built. The workflow refuses fork pull requests with a clear message rather than failing
   halfway through a build.
 - **One box, shared resources.** Previews run on the same EC2 instance as the pytest workflow
-  and as every other preview. Several previews at once compete for memory and disk. Keep the
-  number of live previews small and let garbage collection do its job.
+  and as every other preview. Several previews at once compete for memory and disk. The preflight
+  and the per-container caps described under **Resource guards** keep that from taking the host
+  down, at the price of refusing the fourth preview outright.
 - **Plain HTTP inside the box.** TLS terminates at nginx. The container speaks HTTP on a
   loopback port and is not reachable from outside the host on its own.
 - **Shared `/rtxcomplete/`.** See the section above.

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -175,7 +175,8 @@ and every container is capped once it runs.
 | `PREVIEW_MEMORY_LIMIT` | `2g` | a preview idles at about 400 MB and was measured at 1889 MiB peak while answering queries. Never set this lower than `2g`, the kernel would kill the container in the middle of a query |
 | `PREVIEW_CPU_LIMIT` | `1.5` | a pathfinder query saturates both vCPUs for about 90 seconds. Half a core stays for nginx and the runner |
 | `PREVIEW_MAX_ACTIVE` | `3` | three previews at 2 GB each still leave room for the pytest workflow on a 7.5 GB box |
-| `PREVIEW_MIN_FREE_DISK_GB` | `10` | one preview image is about 3.94 GB and the build needs room for its layers |
+| `PREVIEW_MIN_FREE_DISK_GB` | `10` | absolute part of the disk floor, one preview image is about 3.94 GB |
+| `PREVIEW_MIN_FREE_DISK_PCT` | `10` | percentage part of the disk floor, the larger of the two wins, about 48 GB on the 485 GB root of cicd.rtx.ai |
 | `PREVIEW_MIN_FREE_RAM_MB` | `2048` | enough for the container that is about to start |
 
 The preflight runs on the full rebuild path only, after the previous container and image for this
@@ -291,7 +292,8 @@ Everything below is read by `deploy/preview/lib.sh` and can be overridden in the
 | `PREVIEW_MEMORY_LIMIT` | `2g` | `docker run --memory` for a preview container. Never lower than `2g` |
 | `PREVIEW_CPU_LIMIT` | `1.5` | `docker run --cpus` for a preview container |
 | `PREVIEW_MAX_ACTIVE` | `3` | how many previews may live on the host at once |
-| `PREVIEW_MIN_FREE_DISK_GB` | `10` | refuse a full rebuild below this much free space on the docker root |
+| `PREVIEW_MIN_FREE_DISK_GB` | `10` | absolute disk floor for a full rebuild, combined with the percentage below |
+| `PREVIEW_MIN_FREE_DISK_PCT` | `10` | percentage of the docker root volume, the larger of the two floors applies |
 | `PREVIEW_MIN_FREE_RAM_MB` | `2048` | refuse a full rebuild below this much available memory |
 | `PREVIEW_WEB_ROOT` | `/var/www/arax-preview` | document root of the status page, per-PR reports go in `data/<PR>/` |
 | `PREVIEW_LOG_DIR` | `/var/log/arax-preview` | full deploy logs, pruned after 30 days by `gc.sh` |

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -31,15 +31,18 @@ renames the snippet to `pr-2853.conf`. The port and the container name do not ch
 Three ways, all of which end up running the same scripts on the runner.
 
 - Comment `/deploy` on the pull request. Comment `/undeploy` to remove it again. Only comments
-  from an OWNER, MEMBER or COLLABORATOR are acted on.
+  from an OWNER, MEMBER or COLLABORATOR are acted on. `/deploy --force` skips the fast redeploy
+  described below and always rebuilds the image.
 - Actions tab, pick **Preview Deploy**, **Run workflow**, fill in `pr_number`. Tick `run_tests`
   to also run the ARAX test suite inside the container, and put anything extra in `pytest_args`.
-- On the host directly: `bash deploy/preview/deploy.sh 2853 my-branch`.
+  Tick `force_rebuild` for the same effect as `/deploy --force`.
+- On the host directly: `bash deploy/preview/deploy.sh 2853 my-branch`. Pass the head commit as a
+  third argument to make a fast redeploy possible, and `--force` to rule one out.
 
 The workflow posts one sticky comment on the pull request with the URL, the branch and short
-commit, and the smoke test table. Redeploying updates that same comment instead of adding a
-new one. A refused `/deploy` (fork pull request, closed pull request) gets a short reply saying
-why.
+commit, whether the deploy was a fast redeploy or a full rebuild, and the smoke test table.
+Redeploying updates that same comment instead of adding a new one. A refused `/deploy` (fork pull
+request, closed pull request) gets a short reply saying why.
 
 The scripts always run from the workflow's own branch on master, never from the pull
 request. The pull request head is checked out
@@ -54,6 +57,9 @@ in the Actions tab. Test on the host with `deploy/preview/deploy.sh` until then,
 triggers immediately after the merge.
 
 ## How it works
+
+The flow below is the full rebuild. A redeploy of a preview that is still running usually takes
+the shorter path described in the next section.
 
 ```
   PR comment "/deploy"  or  Actions "Run workflow"
@@ -107,6 +113,41 @@ Inside the container, apache serves the ARAX UI from the checked out repository 
 `/api/arax/v1.4` to the Flask service on port 5000. The UI asks for its API with a relative
 path, so it does not care that nginx stripped a prefix in front of it.
 
+## Fast redeploy
+
+Rebuilding the image takes about six minutes, and most pushes to a pull request change nothing
+that the image bakes in. `deploy.sh` therefore checks whether it can move the existing container
+to the new commit instead, which takes roughly 15 to 30 seconds.
+
+It goes the fast way when all of this holds:
+
+- the container `rtx_pr_<PR>` for that pull request exists and is running
+- `--force` was not given
+- a commit sha was passed, which the workflow always does
+- that commit is on `origin` once the container has fetched
+- `git diff` between the commit checked out in the container and the target commit is empty for
+  `requirements.txt`, `DockerBuild/` and `code/config_dbs.json`
+
+Those three paths are the gate because a change to them cannot be picked up by a checkout inside
+a container that is already running. The first two are baked into the image, and `config_dbs.json`
+decides which database files the container was set up with.
+
+A fast redeploy checks the repository clone inside the container out on the target commit as user
+`rt` with a detached HEAD, reruns `ARAX_database_manager.py` and `kp_info_cacher.py`, and restarts
+`RTX_OpenAPI_production` and `RTX_Complete`. Apache is left alone, because it serves the UI
+straight from that working tree and picks up UI changes with no restart. The nginx snippet is
+rewritten so its header names the new commit, and nginx is only reloaded when the routing itself
+changed.
+
+The commit a preview is running is read with `git rev-parse HEAD` inside the container, never from
+the `arax.preview.sha` label. Docker labels cannot be changed on a running container, so that
+label keeps naming the commit the image was built from.
+
+Anything that does not qualify falls back to the full rebuild, and the reason for it is printed
+in the log, in the summary and in the sticky pull request comment. A fast redeploy that fails its
+health check stops there rather than rebuilding behind your back, and tells you to rerun with
+`--force`.
+
 ## One-time host setup
 
 Run this once on `cicd.rtx.ai`, as a human with sudo:
@@ -146,6 +187,7 @@ Everything below is read by `deploy/preview/lib.sh` and can be overridden in the
 | `PREVIEW_CONFIG_SECRETS` | `/mnt/config/config_secrets.json` | host secrets file mounted into every preview |
 | `PREVIEW_TTL_DAYS` | `7` | age after which garbage collection removes a preview |
 | `PREVIEW_HEALTH_TIMEOUT` | `900` | seconds to wait for the ARAX status endpoint after start |
+| `PREVIEW_FAST_HEALTH_TIMEOUT` | `180` | same wait after a fast redeploy, where only the Flask services restart |
 | `PREVIEW_REPO` | `RTXteam/RTX` | repository the pull request state is checked against |
 | `PREVIEW_BUILD_CONTEXT` | `<repo>/DockerBuild` | docker build context, the workflow points it at `pr-head/DockerBuild` |
 | `PREVIEW_DOCKERFILE` | `$PREVIEW_BUILD_CONTEXT/CICD-Dockerfile` | Dockerfile used for the image |
@@ -167,8 +209,10 @@ next newest, and removes the route entirely when no previews are left.
 
 ## Lifecycle
 
-- **Redeploy** replaces. `deploy.sh` removes the existing container and image for that PR before
-  it builds, so the URL stays the same and always serves the latest push you deployed.
+- **Redeploy** takes one of two paths, and the URL stays the same either way. When the preview is
+  still running and nothing changed that the image bakes in, `deploy.sh` moves the container to
+  the new commit and restarts the Flask services. Otherwise it removes the existing container and
+  image for that pull request and builds again from scratch. See **Fast redeploy** above.
 - **Teardown on close.** Closing or merging a pull request triggers the teardown job, which
   removes the container, the image and the nginx snippet.
 - **Daily garbage collection.** A scheduled run of `gc.sh` removes previews older than
@@ -180,6 +224,12 @@ next newest, and removes the route entirely when no previews are left.
 ```
 # deploy or redeploy a preview
 bash deploy/preview/deploy.sh 2853 my-branch
+
+# redeploy with a commit, which allows the fast path
+bash deploy/preview/deploy.sh 2853 my-branch 0123456789abcdef0123456789abcdef01234567
+
+# redeploy and always rebuild the image
+bash deploy/preview/deploy.sh --force 2853 my-branch
 
 # remove one preview
 bash deploy/preview/teardown.sh 2853

--- a/deploy/preview/deploy.sh
+++ b/deploy/preview/deploy.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
 # Deploy one ARAX preview environment for a pull request on cicd.rtx.ai.
-# Idempotent: running it again replaces the container, the image and the
-# nginx snippet for that PR.
+# Idempotent: running it again either fast redeploys the container that is
+# already up, or replaces the container, the image and the nginx snippet.
 #
-# Usage: deploy.sh <PR> <BRANCH> [SHA]
+# Usage: deploy.sh [--force] <PR> <BRANCH> [SHA]
 #
 # Issue #2846.
 
@@ -16,11 +16,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
     cat >&2 <<'USAGE_EOF'
-Usage: deploy.sh <PR> <BRANCH> [SHA]
+Usage: deploy.sh [--force] <PR> <BRANCH> [SHA]
 
-  PR      pull request number, for example 2853
-  BRANCH  branch name on RTXteam/RTX, for example issue-2846
-  SHA     optional commit sha, recorded as a container label only
+  PR       pull request number, for example 2853
+  BRANCH   branch name on RTXteam/RTX, for example issue-2846
+  SHA      optional commit sha. With a sha the script can fast redeploy an
+           already running preview instead of rebuilding its image.
+  --force  always rebuild the image, even when a fast redeploy is possible.
+           May appear before or after the positional arguments.
 USAGE_EOF
     exit 2
 }
@@ -29,11 +32,39 @@ USAGE_EOF
 # 1. Validate arguments and the host setup
 # ---------------------------------------------------------------------------
 
-[ "$#" -ge 2 ] || usage
+FORCE="no"
+PR=""
+BRANCH=""
+SHA=""
+POSITIONAL_COUNT=0
 
-PR="$1"
-BRANCH="$2"
-SHA="${3:-unknown}"
+# Hand rolled parsing rather than getopts, because --force has to be accepted
+# on either side of the positional arguments.
+for arg in "$@"; do
+    case "${arg}" in
+        --force)
+            FORCE="yes"
+            ;;
+        -h|--help)
+            usage
+            ;;
+        -*)
+            die "unknown option '${arg}'"
+            ;;
+        *)
+            POSITIONAL_COUNT=$(( POSITIONAL_COUNT + 1 ))
+            case "${POSITIONAL_COUNT}" in
+                1) PR="${arg}" ;;
+                2) BRANCH="${arg}" ;;
+                3) SHA="${arg}" ;;
+                *) die "too many arguments, expected at most PR, BRANCH and SHA" ;;
+            esac
+            ;;
+    esac
+done
+
+[ "${POSITIONAL_COUNT}" -ge 2 ] || usage
+[ -n "${SHA}" ] || SHA="unknown"
 
 require_int "${PR}" "PR number"
 [ -n "${BRANCH}" ] || die "branch name must not be empty"
@@ -44,9 +75,18 @@ IMAGE="$(preview_image "${PR}")"
 PUBLIC_PATH="$(preview_path "${PR}")"
 PUBLIC_URL="$(preview_url "${PR}")"
 NGINX_CONF="$(preview_nginx_conf "${PR}")"
+HEALTH_URL="http://127.0.0.1:${PORT}/api/arax/v1.4/status"
 
-log "step 1/8 validating host setup"
-log "PR ${PR}, branch ${BRANCH}, sha ${SHA}"
+# Where CICD-Dockerfile puts the clone it makes inside the image.
+CONTAINER_REPO="/mnt/data/orangeboard/production/RTX"
+# A change to any of these cannot be picked up by a git checkout inside the
+# running container: requirements.txt and DockerBuild/ are baked into the
+# image at build time, and config_dbs.json decides which database files the
+# container was set up with.
+FAST_GATE_PATHS="requirements.txt DockerBuild/ code/config_dbs.json"
+
+log "step 1/10 validating host setup"
+log "PR ${PR}, branch ${BRANCH}, sha ${SHA}, force ${FORCE}"
 log "container ${CONTAINER}, image ${IMAGE}, port 127.0.0.1:${PORT}"
 log "public url ${PUBLIC_URL}"
 
@@ -60,91 +100,109 @@ fi
 log "build context ${PREVIEW_BUILD_CONTEXT}, dockerfile ${PREVIEW_DOCKERFILE}"
 
 # ---------------------------------------------------------------------------
-# 2. Remove anything left over from a previous deploy of this PR
+# Helpers shared by both paths
 # ---------------------------------------------------------------------------
 
-log "step 2/8 removing any previous container and image for PR ${PR}"
-${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || log "no previous container ${CONTAINER}"
-${DOCKER} rmi -f "${IMAGE}" >/dev/null 2>&1 || log "no previous image ${IMAGE}"
+# container_git <git command words>
+# The clone inside the container belongs to user rt and apache serves it, so
+# every git command has to run as rt. Running it as root would leave root
+# owned objects in .git and trip git's dubious ownership check afterwards.
+container_git() {
+    local cmd="$*"
+    ${DOCKER} exec "${CONTAINER}" bash -c "sudo -u rt bash -c 'cd ${CONTAINER_REPO} && ${cmd}'"
+}
 
-# ---------------------------------------------------------------------------
-# 3. Build the image
-# ---------------------------------------------------------------------------
+# True for something that looks like a git object name. This also keeps the
+# value safe to interpolate into the nested shell command above.
+is_sha() {
+    local value="${1:-}"
+    case "${value}" in
+        ''|*[!0-9a-fA-F]*) return 1 ;;
+    esac
+    [ "${#value}" -ge 7 ]
+}
 
-# CICD-Dockerfile git clones RTXteam/RTX inside the image and checks out
-# BUILD_BRANCH, so the branch has to exist on the upstream repository. Fork
-# pull requests cannot work with this build and are refused by the workflow.
-log "step 3/8 building ${IMAGE} from branch ${BRANCH} (this takes a while)"
-${DOCKER} build \
-    --no-cache=true \
-    --rm \
-    --build-arg "BUILD_BRANCH=${BRANCH}" \
-    -t "${IMAGE}" \
-    -f "${PREVIEW_DOCKERFILE}" \
-    "${PREVIEW_BUILD_CONTEXT}/"
+# wait_healthy <seconds>
+# Polls the container's own status endpoint. Returns non-zero on timeout so
+# the caller can decide what to log and how to fail.
+wait_healthy() {
+    local timeout="${1}"
+    local deadline
+    deadline=$(( $(date -u '+%s') + timeout ))
+    while [ "$(date -u '+%s')" -lt "${deadline}" ]; do
+        if curl -fsS -o /dev/null -m 15 "${HEALTH_URL}"; then
+            return 0
+        fi
+        sleep 10
+    done
+    return 1
+}
 
-# ---------------------------------------------------------------------------
-# 4. Run the container and start the services inside it
-# ---------------------------------------------------------------------------
+# Only the lines nginx acts on. The header comment carries a timestamp that
+# changes on every run, so comparing whole files would always report a change.
+nginx_conf_body() {
+    ${SUDO} cat "${1}" 2>/dev/null | grep -v '^#' || true
+}
 
-CREATED="$(date -u '+%s')"
-
-# The image has no CMD and no ENTRYPOINT, so it needs -d -i -t to stay up,
-# exactly like the pytest workflow does.
-log "step 4/8 starting ${CONTAINER} on 127.0.0.1:${PORT}"
-${DOCKER} run -d -i -t \
-    --name "${CONTAINER}" \
-    -p "127.0.0.1:${PORT}:80" \
-    -v "${PREVIEW_DB_DIR}:/mnt/data/orangeboard/databases" \
-    -v "${PREVIEW_CONFIG_SECRETS}:/mnt/data/orangeboard/production/RTX/code/config_secrets.json" \
-    --label "arax.preview=true" \
-    --label "arax.preview.pr=${PR}" \
-    --label "arax.preview.branch=${BRANCH}" \
-    --label "arax.preview.sha=${SHA}" \
-    --label "arax.preview.created=${CREATED}" \
-    "${IMAGE}"
-
-log "creating database symlinks"
-${DOCKER} exec "${CONTAINER}" bash -c "sudo -u rt bash -c 'cd /mnt/data/orangeboard/production/RTX && python3 code/ARAX/ARAXQuery/ARAX_database_manager.py'"
-
-log "building the KP info cache"
-${DOCKER} exec "${CONTAINER}" bash -c "cd /mnt/data/orangeboard/production/RTX/code/ARAX/ARAXQuery/Expand && python3 kp_info_cacher.py"
-
-log "starting apache2, RTX_OpenAPI_production and RTX_Complete"
-${DOCKER} exec "${CONTAINER}" service apache2 start
-${DOCKER} exec "${CONTAINER}" service RTX_OpenAPI_production start
-${DOCKER} exec "${CONTAINER}" service RTX_Complete start
-
-# ---------------------------------------------------------------------------
-# 5. Publish the preview through nginx
-# ---------------------------------------------------------------------------
-
-log "step 5/8 writing ${NGINX_CONF}"
-
-# Keep a copy of the shared autocomplete snippet so a failed nginx -t can be
-# rolled back to exactly what was there before.
+NGINX_CONF_BACKUP=""
 RTXCOMPLETE_BACKUP=""
-if ${SUDO} test -f "${PREVIEW_RTXCOMPLETE_CONF}"; then
-    RTXCOMPLETE_BACKUP="$(mktemp)"
-    ${SUDO} cat "${PREVIEW_RTXCOMPLETE_CONF}" > "${RTXCOMPLETE_BACKUP}"
-fi
 
+# Puts the two snippets back exactly as they were, then reloads. Restoring
+# beats deleting: on a fast redeploy the previous snippet was serving a
+# working preview.
 rollback_nginx() {
-    ${SUDO} rm -f "${NGINX_CONF}"
+    if [ -n "${NGINX_CONF_BACKUP}" ]; then
+        ${SUDO} tee "${NGINX_CONF}" >/dev/null < "${NGINX_CONF_BACKUP}"
+    else
+        ${SUDO} rm -f "${NGINX_CONF}"
+    fi
     if [ -n "${RTXCOMPLETE_BACKUP}" ]; then
         ${SUDO} tee "${PREVIEW_RTXCOMPLETE_CONF}" >/dev/null < "${RTXCOMPLETE_BACKUP}"
     else
         ${SUDO} rm -f "${PREVIEW_RTXCOMPLETE_CONF}"
     fi
-    rm -f "${RTXCOMPLETE_BACKUP}"
+    clean_nginx_backups
     # Best effort: put nginx back on the configuration it had before.
     nginx_reload || log "nginx did not reload after rollback, inspect the host by hand"
 }
 
-# The trailing slash on proxy_pass is what strips the /<PR>/ prefix before the
-# request reaches apache in the container.
-${SUDO} tee "${NGINX_CONF}" >/dev/null <<NGINX_EOF
-# managed by deploy/preview/deploy.sh, PR ${PR}, branch ${BRANCH}, sha ${SHA}, created $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+clean_nginx_backups() {
+    if [ -n "${NGINX_CONF_BACKUP}" ]; then
+        rm -f "${NGINX_CONF_BACKUP}"
+        NGINX_CONF_BACKUP=""
+    fi
+    if [ -n "${RTXCOMPLETE_BACKUP}" ]; then
+        rm -f "${RTXCOMPLETE_BACKUP}"
+        RTXCOMPLETE_BACKUP=""
+    fi
+}
+
+# publish_nginx <always|if-changed>
+# Writes both snippets and reloads nginx. With if-changed the reload is
+# skipped when the effective configuration is byte for byte what it already
+# was, which is the normal case for a fast redeploy.
+publish_nginx() {
+    local reload_mode="${1}"
+    local before_conf before_shared after_conf after_shared
+
+    before_conf="$(nginx_conf_body "${NGINX_CONF}")"
+    before_shared="$(nginx_conf_body "${PREVIEW_RTXCOMPLETE_CONF}")"
+
+    # Keep copies so a failed nginx -t can be rolled back to exactly what was
+    # there before.
+    if ${SUDO} test -f "${NGINX_CONF}"; then
+        NGINX_CONF_BACKUP="$(mktemp)"
+        ${SUDO} cat "${NGINX_CONF}" > "${NGINX_CONF_BACKUP}"
+    fi
+    if ${SUDO} test -f "${PREVIEW_RTXCOMPLETE_CONF}"; then
+        RTXCOMPLETE_BACKUP="$(mktemp)"
+        ${SUDO} cat "${PREVIEW_RTXCOMPLETE_CONF}" > "${RTXCOMPLETE_BACKUP}"
+    fi
+
+    # The trailing slash on proxy_pass is what strips the /<PR>/ prefix before
+    # the request reaches apache in the container.
+    ${SUDO} tee "${NGINX_CONF}" >/dev/null <<NGINX_EOF
+# managed by deploy/preview/deploy.sh, PR ${PR}, branch ${BRANCH}, sha ${SHA}, written $(date -u '+%Y-%m-%dT%H:%M:%SZ')
 location = ${PUBLIC_PATH} { return 301 ${PUBLIC_PATH}/; }
 location ${PUBLIC_PATH}/ {
     proxy_pass http://127.0.0.1:${PORT}/;
@@ -158,43 +216,216 @@ location ${PUBLIC_PATH}/ {
 }
 NGINX_EOF
 
-write_rtxcomplete_conf "${PORT}" "${PR}"
+    write_rtxcomplete_conf "${PORT}" "${PR}"
 
-if ! nginx_reload; then
-    rollback_nginx
-    die "nginx rejected the preview configuration for PR ${PR}, rolled back"
-fi
-rm -f "${RTXCOMPLETE_BACKUP}"
+    after_conf="$(nginx_conf_body "${NGINX_CONF}")"
+    after_shared="$(nginx_conf_body "${PREVIEW_RTXCOMPLETE_CONF}")"
 
-# ---------------------------------------------------------------------------
-# 6. Wait for the ARAX API to come up
-# ---------------------------------------------------------------------------
-
-HEALTH_URL="http://127.0.0.1:${PORT}/api/arax/v1.4/status"
-log "step 6/8 polling ${HEALTH_URL} for up to ${PREVIEW_HEALTH_TIMEOUT}s"
-
-DEADLINE=$(( $(date -u '+%s') + PREVIEW_HEALTH_TIMEOUT ))
-HEALTHY="no"
-while [ "$(date -u '+%s')" -lt "${DEADLINE}" ]; do
-    if curl -fsS -o /dev/null -m 15 "${HEALTH_URL}"; then
-        HEALTHY="yes"
-        break
+    if [ "${reload_mode}" = "if-changed" ] \
+        && [ "${before_conf}" = "${after_conf}" ] \
+        && [ "${before_shared}" = "${after_shared}" ]; then
+        log "nginx routing is unchanged, skipping the reload"
+        clean_nginx_backups
+        return 0
     fi
-    sleep 10
-done
 
-if [ "${HEALTHY}" != "yes" ]; then
-    log "the preview never answered ${HEALTH_URL}, last 200 lines of container output follow"
-    ${DOCKER} logs --tail 200 "${CONTAINER}" >&2 || true
-    die "PR ${PR} preview failed its health check after ${PREVIEW_HEALTH_TIMEOUT}s"
+    if ! nginx_reload; then
+        rollback_nginx
+        die "nginx rejected the preview configuration for PR ${PR}, rolled back"
+    fi
+    clean_nginx_backups
+}
+
+# ---------------------------------------------------------------------------
+# 2. Decide between a fast redeploy and a full rebuild
+# ---------------------------------------------------------------------------
+
+MODE="full"
+REASON=""
+RUNNING_SHA=""
+
+# Sets MODE and REASON. Every reason to fall back is a plain return, never a
+# failure, because a full rebuild is always a correct answer.
+decide_mode() {
+    local changed=""
+
+    if [ "${FORCE}" = "yes" ]; then
+        REASON="--force was given"
+        return 0
+    fi
+    if ! is_sha "${SHA}"; then
+        REASON="no commit sha was passed"
+        return 0
+    fi
+    if ! container_running "${CONTAINER}"; then
+        REASON="no running container ${CONTAINER}"
+        return 0
+    fi
+
+    # The arax.preview.sha label is deliberately not used here. Labels cannot
+    # be changed on a running container, so the label still names the commit
+    # the image was built from after any fast redeploy.
+    RUNNING_SHA="$(container_git git rev-parse HEAD | tr -d '[:space:]')" || RUNNING_SHA=""
+    if ! is_sha "${RUNNING_SHA}"; then
+        REASON="could not read the sha checked out in ${CONTAINER}"
+        return 0
+    fi
+    log "${CONTAINER} currently has ${RUNNING_SHA} checked out"
+
+    if ! container_git git fetch origin; then
+        REASON="git fetch origin failed inside ${CONTAINER}"
+        return 0
+    fi
+    if ! container_git "git cat-file -e ${SHA}^{commit}"; then
+        REASON="target sha not on origin"
+        return 0
+    fi
+
+    if ! changed="$(container_git "git diff --name-only ${RUNNING_SHA} ${SHA} -- ${FAST_GATE_PATHS}" | tr '\n' ' ')"; then
+        REASON="git diff failed inside ${CONTAINER}"
+        return 0
+    fi
+    # Collapse the file list onto one line so it can be a GITHUB_OUTPUT value.
+    changed="$(printf '%s' "${changed}" | sed 's/  */ /g; s/ $//')"
+    if [ -n "${changed}" ]; then
+        REASON="image inputs changed: ${changed}"
+        return 0
+    fi
+
+    MODE="fast"
+    REASON="no image inputs changed between ${RUNNING_SHA} and ${SHA}"
+}
+
+log "step 2/10 deciding how to deploy"
+decide_mode
+if [ "${MODE}" = "fast" ]; then
+    log "mode: fast (${REASON})"
+else
+    log "mode: full rebuild (${REASON})"
 fi
-log "health check passed"
+
+if [ "${MODE}" = "fast" ]; then
+
+    # -----------------------------------------------------------------------
+    # Fast path: move the clone inside the running container to the new commit
+    # and restart the two Flask services. No image build, no new container.
+    # -----------------------------------------------------------------------
+
+    # 3. Move the working tree onto the new commit
+    log "step 3/10 checking out ${SHA} inside ${CONTAINER}"
+    # Detached on purpose. The preview only ever has to match one commit, and
+    # a detached HEAD cannot drift with a force pushed branch.
+    if ! container_git "git checkout --detach ${SHA}"; then
+        die "git checkout ${SHA} failed inside ${CONTAINER}. Rerun deploy.sh with --force to rebuild this preview from scratch."
+    fi
+
+    # 4. Database symlinks, in case the new commit changed config_dbs.json
+    #    in a way that only adds or renames a symlink.
+    log "step 4/10 refreshing database symlinks"
+    ${DOCKER} exec "${CONTAINER}" bash -c "sudo -u rt bash -c 'cd /mnt/data/orangeboard/production/RTX && python3 code/ARAX/ARAXQuery/ARAX_database_manager.py'"
+
+    # 5. KP info cache
+    log "step 5/10 rebuilding the KP info cache"
+    ${DOCKER} exec "${CONTAINER}" bash -c "cd /mnt/data/orangeboard/production/RTX/code/ARAX/ARAXQuery/Expand && python3 kp_info_cacher.py"
+
+    # 6. Restart the Flask services only. Apache serves the UI straight from
+    #    the working tree, so UI changes are already live without a restart.
+    log "step 6/10 restarting RTX_OpenAPI_production and RTX_Complete"
+    ${DOCKER} exec "${CONTAINER}" service RTX_OpenAPI_production restart
+    ${DOCKER} exec "${CONTAINER}" service RTX_Complete restart
+
+    # 7. nginx. The routing is almost certainly identical, the rewrite is here
+    #    to keep the sha in the header honest.
+    log "step 7/10 refreshing ${NGINX_CONF}"
+    publish_nginx "if-changed"
+
+    # 8. Health
+    log "step 8/10 polling ${HEALTH_URL} for up to ${PREVIEW_FAST_HEALTH_TIMEOUT}s"
+    if ! wait_healthy "${PREVIEW_FAST_HEALTH_TIMEOUT}"; then
+        log "the preview never answered ${HEALTH_URL}, last 200 lines of container output follow"
+        ${DOCKER} logs --tail 200 "${CONTAINER}" >&2 || true
+        # No automatic rebuild here. A fast redeploy that fails is worth
+        # looking at, and a silent six minute rebuild would hide it.
+        die "PR ${PR} fast redeploy failed its health check after ${PREVIEW_FAST_HEALTH_TIMEOUT}s. Rerun deploy.sh with --force to rebuild this preview from scratch."
+    fi
+    log "health check passed"
+
+else
+
+    # -----------------------------------------------------------------------
+    # Full path: rebuild the image and replace the container.
+    # -----------------------------------------------------------------------
+
+    # 3. Remove anything left over from a previous deploy of this PR
+    log "step 3/10 removing any previous container and image for PR ${PR}"
+    ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || log "no previous container ${CONTAINER}"
+    ${DOCKER} rmi -f "${IMAGE}" >/dev/null 2>&1 || log "no previous image ${IMAGE}"
+
+    # 4. Build the image
+    #    CICD-Dockerfile git clones RTXteam/RTX inside the image and checks out
+    #    BUILD_BRANCH, so the branch has to exist on the upstream repository.
+    #    Fork pull requests cannot work with this build and are refused by the
+    #    workflow.
+    log "step 4/10 building ${IMAGE} from branch ${BRANCH} (this takes a while)"
+    ${DOCKER} build \
+        --no-cache=true \
+        --rm \
+        --build-arg "BUILD_BRANCH=${BRANCH}" \
+        -t "${IMAGE}" \
+        -f "${PREVIEW_DOCKERFILE}" \
+        "${PREVIEW_BUILD_CONTEXT}/"
+
+    # 5. Run the container
+    CREATED="$(date -u '+%s')"
+
+    # The image has no CMD and no ENTRYPOINT, so it needs -d -i -t to stay up,
+    # exactly like the pytest workflow does.
+    log "step 5/10 starting ${CONTAINER} on 127.0.0.1:${PORT}"
+    ${DOCKER} run -d -i -t \
+        --name "${CONTAINER}" \
+        -p "127.0.0.1:${PORT}:80" \
+        -v "${PREVIEW_DB_DIR}:/mnt/data/orangeboard/databases" \
+        -v "${PREVIEW_CONFIG_SECRETS}:/mnt/data/orangeboard/production/RTX/code/config_secrets.json" \
+        --label "arax.preview=true" \
+        --label "arax.preview.pr=${PR}" \
+        --label "arax.preview.branch=${BRANCH}" \
+        --label "arax.preview.sha=${SHA}" \
+        --label "arax.preview.created=${CREATED}" \
+        "${IMAGE}"
+
+    # 6. Start the services inside it
+    log "step 6/10 setting up databases and starting the services"
+    log "creating database symlinks"
+    ${DOCKER} exec "${CONTAINER}" bash -c "sudo -u rt bash -c 'cd /mnt/data/orangeboard/production/RTX && python3 code/ARAX/ARAXQuery/ARAX_database_manager.py'"
+
+    log "building the KP info cache"
+    ${DOCKER} exec "${CONTAINER}" bash -c "cd /mnt/data/orangeboard/production/RTX/code/ARAX/ARAXQuery/Expand && python3 kp_info_cacher.py"
+
+    log "starting apache2, RTX_OpenAPI_production and RTX_Complete"
+    ${DOCKER} exec "${CONTAINER}" service apache2 start
+    ${DOCKER} exec "${CONTAINER}" service RTX_OpenAPI_production start
+    ${DOCKER} exec "${CONTAINER}" service RTX_Complete start
+
+    # 7. Publish the preview through nginx
+    log "step 7/10 writing ${NGINX_CONF}"
+    publish_nginx "always"
+
+    # 8. Wait for the ARAX API to come up
+    log "step 8/10 polling ${HEALTH_URL} for up to ${PREVIEW_HEALTH_TIMEOUT}s"
+    if ! wait_healthy "${PREVIEW_HEALTH_TIMEOUT}"; then
+        log "the preview never answered ${HEALTH_URL}, last 200 lines of container output follow"
+        ${DOCKER} logs --tail 200 "${CONTAINER}" >&2 || true
+        die "PR ${PR} preview failed its health check after ${PREVIEW_HEALTH_TIMEOUT}s"
+    fi
+    log "health check passed"
+
+fi
 
 # ---------------------------------------------------------------------------
-# 7. Check the public URL, without failing the deploy on it
+# 9. Check the public URL, without failing the deploy on it
 # ---------------------------------------------------------------------------
 
-log "step 7/8 checking the public URL"
+log "step 9/10 checking the public URL"
 if curl -fsS -o /dev/null -m 20 "${PUBLIC_URL}api/arax/v1.4/status"; then
     log "public url ok: ${PUBLIC_URL}"
 else
@@ -202,16 +433,18 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 8. Summary
+# 10. Summary
 # ---------------------------------------------------------------------------
 
-log "step 8/8 done"
+log "step 10/10 done"
 cat <<SUMMARY_EOF
 =====================================================
 ARAX preview deployed
   pr        ${PR}
   branch    ${BRANCH}
   sha       ${SHA}
+  mode      ${MODE}
+  reason    ${REASON}
   url       ${PUBLIC_URL}
   port      127.0.0.1:${PORT}
   container ${CONTAINER}
@@ -227,5 +460,7 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
         printf 'container=%s\n' "${CONTAINER}"
         printf 'image=%s\n' "${IMAGE}"
         printf 'path=%s\n' "${PUBLIC_PATH}"
+        printf 'mode=%s\n' "${MODE}"
+        printf 'reason=%s\n' "${REASON}"
     } >> "${GITHUB_OUTPUT}"
 fi

--- a/deploy/preview/deploy.sh
+++ b/deploy/preview/deploy.sh
@@ -332,19 +332,28 @@ preflight() {
 
     # 2. free space where the image is going to land
     # Both forms can fail on a host that lays its filesystems out differently,
-    # and an unreadable df is a reason to skip the check, not to refuse.
-    avail_gb="$(df -BG --output=avail /var/lib/docker 2>/dev/null \
-        || df -BG --output=avail / 2>/dev/null || true)"
-    avail_gb="$(printf '%s' "${avail_gb}" | tail -n 1 | tr -dc '0-9')"
-    case "${avail_gb}" in
-        ''|*[!0-9]*)
+    # and an unreadable df is a reason to skip the check, not to refuse. The
+    # floor is the larger of PREVIEW_MIN_FREE_DISK_GB and
+    # PREVIEW_MIN_FREE_DISK_PCT percent of the volume, so the same default is
+    # sane on a small host and on the 485 GB root of cicd.rtx.ai.
+    local df_line size_gb avail_gb pct_floor_gb floor_gb
+    df_line="$(df -BG --output=size,avail /var/lib/docker 2>/dev/null \
+        || df -BG --output=size,avail / 2>/dev/null || true)"
+    df_line="$(printf '%s' "${df_line}" | tail -n 1)"
+    size_gb="$(printf '%s' "${df_line}" | awk '{print $1}' | tr -dc '0-9')"
+    avail_gb="$(printf '%s' "${df_line}" | awk '{print $2}' | tr -dc '0-9')"
+    case "${avail_gb}:${size_gb}" in
+        *[!0-9:]*|:*|*:)
             log "WARNING: could not read the free disk space, skipping that check"
             ;;
         *)
-            if [ "${avail_gb}" -lt "${PREVIEW_MIN_FREE_DISK_GB}" ]; then
-                refuse "the preview host has ${avail_gb} GB free where docker stores its images and PREVIEW_MIN_FREE_DISK_GB is ${PREVIEW_MIN_FREE_DISK_GB}. One preview image is about 4 GB. Tear down an old preview or run deploy/preview/gc.sh on cicd.rtx.ai."
+            pct_floor_gb=$(( size_gb * PREVIEW_MIN_FREE_DISK_PCT / 100 ))
+            floor_gb="${PREVIEW_MIN_FREE_DISK_GB}"
+            [ "${pct_floor_gb}" -gt "${floor_gb}" ] && floor_gb="${pct_floor_gb}"
+            if [ "${avail_gb}" -lt "${floor_gb}" ]; then
+                refuse "the preview host has ${avail_gb} GB free of ${size_gb} GB where docker stores its images and the floor is ${floor_gb} GB (the larger of PREVIEW_MIN_FREE_DISK_GB=${PREVIEW_MIN_FREE_DISK_GB} and PREVIEW_MIN_FREE_DISK_PCT=${PREVIEW_MIN_FREE_DISK_PCT}% of the volume). One preview image is about 4 GB. Tear down an old preview or run deploy/preview/gc.sh on cicd.rtx.ai."
             fi
-            log "preflight: ${avail_gb} GB free on the docker root, minimum ${PREVIEW_MIN_FREE_DISK_GB} GB"
+            log "preflight: ${avail_gb} GB free of ${size_gb} GB on the docker root, floor ${floor_gb} GB"
             ;;
     esac
 

--- a/deploy/preview/deploy.sh
+++ b/deploy/preview/deploy.sh
@@ -13,6 +13,7 @@ set -o nounset -o pipefail -o errexit
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "${SCRIPT_DIR}/lib.sh"
+preview_validate_env
 
 usage() {
     cat >&2 <<'USAGE_EOF'

--- a/deploy/preview/deploy.sh
+++ b/deploy/preview/deploy.sh
@@ -69,6 +69,76 @@ done
 require_int "${PR}" "PR number"
 [ -n "${BRANCH}" ] || die "branch name must not be empty"
 
+# ---------------------------------------------------------------------------
+# Log capture and the end of run bookkeeping
+# ---------------------------------------------------------------------------
+
+# Everything printed from here on is copied into a host log file as well, and
+# the tail of that file is what the status page shows under this pull request.
+# The workflow still tees the same output into the job log and the artifact.
+DEPLOY_LOG_FILE=""
+DEPLOY_LOG_TEE_PID=""
+
+setup_log_capture() {
+    [ -n "${PREVIEW_LOG_DIR}" ] || return 0
+    if ! ${SUDO} mkdir -p "${PREVIEW_LOG_DIR}" 2>/dev/null; then
+        log "WARNING: could not create ${PREVIEW_LOG_DIR}, this deploy is not logged to disk"
+        return 0
+    fi
+    ${SUDO} chmod 755 "${PREVIEW_LOG_DIR}" 2>/dev/null || true
+    DEPLOY_LOG_FILE="${PREVIEW_LOG_DIR}/pr${PR}-$(date -u '+%Y%m%dT%H%M%SZ').log"
+    # tee runs through sudo because the directory belongs to root and the
+    # runner user is not root.
+    exec > >(${SUDO} tee -a "${DEPLOY_LOG_FILE}") 2>&1
+    DEPLOY_LOG_TEE_PID="$!"
+    ${SUDO} chmod 644 "${DEPLOY_LOG_FILE}" 2>/dev/null || true
+}
+
+# Copies the tail of this run's log where the status page can show it, then
+# rewrites the status page. Every step is best effort.
+publish_deploy_artifacts() {
+    local tail_text
+    if [ -n "${DEPLOY_LOG_FILE}" ] && ${SUDO} test -f "${DEPLOY_LOG_FILE}"; then
+        # The secrets guard is crude on purpose. The page is public, so a line
+        # that so much as mentions a credential is dropped rather than shown.
+        tail_text="$(${SUDO} tail -n 200 "${DEPLOY_LOG_FILE}" 2>/dev/null \
+            | grep -viE 'password|token|secret|authorization' || true)"
+        printf '%s\n' "${tail_text}" | write_preview_data "${PR}" "deploy-log.txt"
+    fi
+    write_status_page
+}
+
+# Runs on every exit, including the ones die() takes. The original exit status
+# is preserved so nothing here can turn a failed deploy into a green one.
+finalize() {
+    local rc=$?
+    trap - EXIT
+    set +o errexit
+    publish_deploy_artifacts
+    # Let the tee child see end of file and finish writing before this process
+    # goes away, so neither the host log nor the workflow log loses its tail.
+    if [ -n "${DEPLOY_LOG_TEE_PID}" ]; then
+        exec 1>&- 2>&-
+        wait "${DEPLOY_LOG_TEE_PID}" 2>/dev/null || true
+    fi
+    exit "${rc}"
+}
+
+setup_log_capture
+trap finalize EXIT
+
+# refuse <one line reason>
+# A preflight refusal. The reason is handed to the workflow so the pull
+# request comment can say what the host ran out of, rather than the generic
+# "the deploy failed".
+refuse() {
+    local reason="$*"
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        printf 'refused=%s\n' "${reason}" >> "${GITHUB_OUTPUT}"
+    fi
+    die "${reason}"
+}
+
 PORT="$(preview_port "${PR}")"
 CONTAINER="$(preview_container "${PR}")"
 IMAGE="$(preview_image "${PR}")"
@@ -236,6 +306,77 @@ NGINX_EOF
     clean_nginx_backups
 }
 
+# preflight
+# Resource guards for the full path only. The fast path reuses a container
+# that is already running and asks the host for nothing new, so none of this
+# applies to it. Runs after the previous container and image for this pull
+# request are gone, so the space they held counts as free and the port they
+# held reads as free.
+preflight() {
+    local others count avail_gb free_mb
+
+    # 1. how many other previews are on the box. A redeploy of a pull request
+    #    that already has a container is not a new preview, so this PR is
+    #    excluded from the count.
+    others="$(list_preview_prs | sort -n -u | grep -v "^${PR}$" | tr '\n' ' ' | sed 's/  */ /g; s/ $//' || true)"
+    count=0
+    if [ -n "${others}" ]; then
+        # shellcheck disable=SC2086
+        set -- ${others}
+        count="$#"
+    fi
+    if [ "${count}" -ge "${PREVIEW_MAX_ACTIVE}" ]; then
+        refuse "the host already has ${count} other preview(s) deployed, for PR(s) ${others}, and PREVIEW_MAX_ACTIVE is ${PREVIEW_MAX_ACTIVE}. Comment /undeploy on one of them, then deploy this one again."
+    fi
+    log "preflight: ${count} other preview(s) on the host, limit ${PREVIEW_MAX_ACTIVE}"
+
+    # 2. free space where the image is going to land
+    # Both forms can fail on a host that lays its filesystems out differently,
+    # and an unreadable df is a reason to skip the check, not to refuse.
+    avail_gb="$(df -BG --output=avail /var/lib/docker 2>/dev/null \
+        || df -BG --output=avail / 2>/dev/null || true)"
+    avail_gb="$(printf '%s' "${avail_gb}" | tail -n 1 | tr -dc '0-9')"
+    case "${avail_gb}" in
+        ''|*[!0-9]*)
+            log "WARNING: could not read the free disk space, skipping that check"
+            ;;
+        *)
+            if [ "${avail_gb}" -lt "${PREVIEW_MIN_FREE_DISK_GB}" ]; then
+                refuse "the preview host has ${avail_gb} GB free where docker stores its images and PREVIEW_MIN_FREE_DISK_GB is ${PREVIEW_MIN_FREE_DISK_GB}. One preview image is about 4 GB. Tear down an old preview or run deploy/preview/gc.sh on cicd.rtx.ai."
+            fi
+            log "preflight: ${avail_gb} GB free on the docker root, minimum ${PREVIEW_MIN_FREE_DISK_GB} GB"
+            ;;
+    esac
+
+    # 3. available memory. The available column, not the free one: page cache
+    #    is reclaimable and would otherwise read as used.
+    free_mb="$(free -m 2>/dev/null | awk '/^Mem:/{print $7}' || true)"
+    case "${free_mb}" in
+        ''|*[!0-9]*)
+            log "WARNING: could not read the available memory, skipping that check"
+            ;;
+        *)
+            if [ "${free_mb}" -lt "${PREVIEW_MIN_FREE_RAM_MB}" ]; then
+                refuse "the preview host has ${free_mb} MB of memory available and PREVIEW_MIN_FREE_RAM_MB is ${PREVIEW_MIN_FREE_RAM_MB}. A preview peaks at about 1900 MB. Tear down an old preview or wait for the running queries to finish."
+            fi
+            log "preflight: ${free_mb} MB memory available, minimum ${PREVIEW_MIN_FREE_RAM_MB} MB"
+            ;;
+    esac
+
+    # 4. the port. The container for this pull request is gone by now, so
+    #    anything still listening belongs to something else and docker run
+    #    would fail several minutes from now, after the image build.
+    # The connect attempt runs in a subshell for two reasons: a failed exec
+    # redirection can take a non-interactive shell down with it, and a refused
+    # connection is the expected case here. The close is chained with && and
+    # not with a semicolon, because a semicolon would hand the successful
+    # close's exit status to the if and every port would read as taken.
+    if (exec 3<>"/dev/tcp/127.0.0.1/${PORT}" && exec 3<&-) 2>/dev/null; then
+        refuse "something is already listening on 127.0.0.1:${PORT}, which is the port PR ${PR} needs. Find it with 'sudo ss -lptn sport = :${PORT}' on cicd.rtx.ai."
+    fi
+    log "preflight: 127.0.0.1:${PORT} is free"
+}
+
 # ---------------------------------------------------------------------------
 # 2. Decide between a fast redeploy and a full rebuild
 # ---------------------------------------------------------------------------
@@ -356,10 +497,13 @@ else
     # Full path: rebuild the image and replace the container.
     # -----------------------------------------------------------------------
 
-    # 3. Remove anything left over from a previous deploy of this PR
-    log "step 3/10 removing any previous container and image for PR ${PR}"
+    # 3. Remove anything left over from a previous deploy of this PR, then
+    #    check that the host can afford what comes next. Removal comes first
+    #    so the roughly 4 GB the old image held counts as free space.
+    log "step 3/10 clearing the previous deploy of PR ${PR} and checking the host"
     ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || log "no previous container ${CONTAINER}"
     ${DOCKER} rmi -f "${IMAGE}" >/dev/null 2>&1 || log "no previous image ${IMAGE}"
+    preflight
 
     # 4. Build the image
     #    CICD-Dockerfile git clones RTXteam/RTX inside the image and checks out
@@ -380,9 +524,11 @@ else
 
     # The image has no CMD and no ENTRYPOINT, so it needs -d -i -t to stay up,
     # exactly like the pytest workflow does.
-    log "step 5/10 starting ${CONTAINER} on 127.0.0.1:${PORT}"
+    log "step 5/10 starting ${CONTAINER} on 127.0.0.1:${PORT}, capped at ${PREVIEW_MEMORY_LIMIT} memory and ${PREVIEW_CPU_LIMIT} cpus"
     ${DOCKER} run -d -i -t \
         --name "${CONTAINER}" \
+        --memory "${PREVIEW_MEMORY_LIMIT}" \
+        --cpus "${PREVIEW_CPU_LIMIT}" \
         -p "127.0.0.1:${PORT}:80" \
         -v "${PREVIEW_DB_DIR}:/mnt/data/orangeboard/databases" \
         -v "${PREVIEW_CONFIG_SECRETS}:/mnt/data/orangeboard/production/RTX/code/config_secrets.json" \

--- a/deploy/preview/gc.sh
+++ b/deploy/preview/gc.sh
@@ -17,6 +17,7 @@ set -o nounset -o pipefail -o errexit
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "${SCRIPT_DIR}/lib.sh"
+preview_validate_env
 
 DRY_RUN="no"
 while [ "$#" -gt 0 ]; do

--- a/deploy/preview/gc.sh
+++ b/deploy/preview/gc.sh
@@ -173,3 +173,24 @@ else
     log "pruning dangling images"
     ${DOCKER} image prune -f
 fi
+
+# Deploy logs outlive the previews they belong to on purpose, so a preview that
+# is already gone can still be looked at. A month is long enough for that.
+if ${SUDO} test -d "${PREVIEW_LOG_DIR}"; then
+    if [ "${DRY_RUN}" = "yes" ]; then
+        printf 'dry run: would delete files under %s older than 30 days\n' "${PREVIEW_LOG_DIR}"
+    else
+        log "deleting deploy logs under ${PREVIEW_LOG_DIR} older than 30 days"
+        ${SUDO} find "${PREVIEW_LOG_DIR}" -type f -mtime +30 -delete \
+            || log "WARNING: could not prune ${PREVIEW_LOG_DIR}"
+    fi
+else
+    log "no ${PREVIEW_LOG_DIR} on this host, no deploy logs to prune"
+fi
+
+# Last, so the page reflects the sweep that just happened.
+if [ "${DRY_RUN}" = "yes" ]; then
+    printf 'dry run: would rewrite the status page\n'
+else
+    write_status_page
+fi

--- a/deploy/preview/install-nginx-include.sh
+++ b/deploy/preview/install-nginx-include.sh
@@ -34,11 +34,60 @@ ${SUDO} chmod 755 "${PREVIEW_NGINX_DIR}"
 log "${PREVIEW_NGINX_DIR} is ready"
 
 # ---------------------------------------------------------------------------
+# The status page: its document root, the deploy log directory and the nginx
+# snippet that serves both it and the redirect from the bare root.
+# ---------------------------------------------------------------------------
+
+STATUS_CONF_CREATED="no"
+
+ensure_status_assets() {
+    ${SUDO} mkdir -p "${PREVIEW_WEB_ROOT}/data"
+    ${SUDO} chmod 755 "${PREVIEW_WEB_ROOT}" "${PREVIEW_WEB_ROOT}/data"
+    ${SUDO} mkdir -p "${PREVIEW_LOG_DIR}"
+    ${SUDO} chmod 755 "${PREVIEW_LOG_DIR}"
+    log "${PREVIEW_WEB_ROOT} and ${PREVIEW_LOG_DIR} are ready"
+
+    if ${SUDO} test -f "${PREVIEW_STATUS_CONF}"; then
+        log "${PREVIEW_STATUS_CONF} is already there, leaving it alone"
+    else
+        # The exact match on / only catches the bare root, so /cicd.txt and
+        # /.well-known/ keep being served by the site file as before. The
+        # trailing slash on the alias is required by nginx.
+        ${SUDO} tee "${PREVIEW_STATUS_CONF}" >/dev/null <<STATUS_EOF
+# managed by deploy/preview/install-nginx-include.sh
+location = / { return 302 /previews/; }
+location /previews/ {
+    alias ${PREVIEW_WEB_ROOT}/;
+    index index.html;
+    default_type text/html;
+}
+STATUS_EOF
+        STATUS_CONF_CREATED="yes"
+        log "wrote ${PREVIEW_STATUS_CONF}"
+    fi
+
+    # So that /previews/ answers with the empty state right away, before any
+    # preview has ever been deployed on this host.
+    write_status_page
+}
+
+ensure_status_assets
+
+# ---------------------------------------------------------------------------
 # The include line
 # ---------------------------------------------------------------------------
 
 if ${SUDO} grep -qF "${INCLUDE_MARKER}" "${PREVIEW_NGINX_SITE}"; then
     printf 'already installed: %s already contains "%s"\n' "${PREVIEW_NGINX_SITE}" "${INCLUDE_MARKER}"
+    # Nothing else changed, so nginx only has to hear about a snippet that was
+    # written just now.
+    if [ "${STATUS_CONF_CREATED}" = "yes" ]; then
+        if ! nginx_reload; then
+            ${SUDO} rm -f "${PREVIEW_STATUS_CONF}"
+            die "nginx rejected ${PREVIEW_STATUS_CONF}, removed it again and did not reload"
+        fi
+        printf 'added the status page at %s/previews/\n' "${PREVIEW_PUBLIC_BASE_URL%/}"
+    fi
     exit 0
 fi
 
@@ -132,6 +181,10 @@ log "inserted the include at line ${INSERTED_AT} of ${PREVIEW_NGINX_SITE}"
 if ! ${SUDO} nginx -t; then
     ${SUDO} cp -p "${BACKUP}" "${PREVIEW_NGINX_SITE}"
     log "nginx -t failed, restored ${PREVIEW_NGINX_SITE} from ${BACKUP}"
+    if [ "${STATUS_CONF_CREATED}" = "yes" ]; then
+        ${SUDO} rm -f "${PREVIEW_STATUS_CONF}"
+        log "also removed ${PREVIEW_STATUS_CONF}, which this run had just written"
+    fi
     die "nginx rejected the edited configuration, nothing was changed"
 fi
 
@@ -146,6 +199,9 @@ Installed.
   backup         ${BACKUP}
   snippet dir    ${PREVIEW_NGINX_DIR}
   include line   ${INCLUDE_LINE}
+  status page    ${PREVIEW_PUBLIC_BASE_URL%/}/previews/
+  page root      ${PREVIEW_WEB_ROOT}
+  deploy logs    ${PREVIEW_LOG_DIR}
 
 The GitHub Actions runner user also needs passwordless sudo for docker, nginx,
 systemctl reload nginx, tee, rm and mkdir. That is already the case on

--- a/deploy/preview/lib.sh
+++ b/deploy/preview/lib.sh
@@ -114,6 +114,30 @@ die() {
 # Naming helpers
 # ---------------------------------------------------------------------------
 
+# preview_validate_env
+# Every numeric knob can be overridden from the environment, and a typo there
+# must fail here, before any work happens, with the variable named. Without
+# this a bad value would abort six minutes into a build with a bash
+# arithmetic error that names nothing.
+preview_validate_env() {
+    local pair name value
+    for pair in \
+        "PREVIEW_PORT_BASE=${PREVIEW_PORT_BASE}" \
+        "PREVIEW_TTL_DAYS=${PREVIEW_TTL_DAYS}" \
+        "PREVIEW_HEALTH_TIMEOUT=${PREVIEW_HEALTH_TIMEOUT}" \
+        "PREVIEW_FAST_HEALTH_TIMEOUT=${PREVIEW_FAST_HEALTH_TIMEOUT}" \
+        "PREVIEW_MAX_ACTIVE=${PREVIEW_MAX_ACTIVE}" \
+        "PREVIEW_MIN_FREE_DISK_GB=${PREVIEW_MIN_FREE_DISK_GB}" \
+        "PREVIEW_MIN_FREE_DISK_PCT=${PREVIEW_MIN_FREE_DISK_PCT}" \
+        "PREVIEW_MIN_FREE_RAM_MB=${PREVIEW_MIN_FREE_RAM_MB}"; do
+        name="${pair%%=*}"
+        value="${pair#*=}"
+        case "${value}" in
+            ''|*[!0-9]*) die "${name} must be a positive integer, got '${value}'" ;;
+        esac
+    done
+}
+
 # require_int <value> <name>
 # Fails unless the value is a positive integer with no leading sign or zero.
 require_int() {

--- a/deploy/preview/lib.sh
+++ b/deploy/preview/lib.sh
@@ -34,6 +34,9 @@ PREVIEW_CONFIG_SECRETS="${PREVIEW_CONFIG_SECRETS:-/mnt/config/config_secrets.jso
 PREVIEW_TTL_DAYS="${PREVIEW_TTL_DAYS:-7}"
 # Seconds to wait for the ARAX Flask service to answer /status after start.
 PREVIEW_HEALTH_TIMEOUT="${PREVIEW_HEALTH_TIMEOUT:-900}"
+# Same wait for a fast redeploy. The image, the databases and the KP info cache
+# are already in place there, so only the Flask services have to come back.
+PREVIEW_FAST_HEALTH_TIMEOUT="${PREVIEW_FAST_HEALTH_TIMEOUT:-180}"
 # Repository the previews are built from. CICD-Dockerfile clones this by name.
 PREVIEW_REPO="${PREVIEW_REPO:-RTXteam/RTX}"
 # Docker build context and Dockerfile. The workflow points these at a checkout
@@ -51,7 +54,7 @@ SUDO="${SUDO-sudo}"
 
 export PREVIEW_PATH_PREFIX PREVIEW_PORT_BASE PREVIEW_NGINX_DIR \
     PREVIEW_PUBLIC_BASE_URL PREVIEW_DB_DIR PREVIEW_CONFIG_SECRETS \
-    PREVIEW_TTL_DAYS PREVIEW_HEALTH_TIMEOUT PREVIEW_REPO \
+    PREVIEW_TTL_DAYS PREVIEW_HEALTH_TIMEOUT PREVIEW_FAST_HEALTH_TIMEOUT PREVIEW_REPO \
     PREVIEW_BUILD_CONTEXT PREVIEW_DOCKERFILE DOCKER SUDO
 
 # Name of the shared autocomplete snippet. Leading underscore keeps it sorted
@@ -203,6 +206,18 @@ preview_label() {
     local container
     container="$(preview_container "${pr}")"
     ${DOCKER} inspect --format "{{index .Config.Labels \"${key}\"}}" "${container}" 2>/dev/null || true
+}
+
+# container_running <name>
+# True when the container exists and is running. Anything else, including a
+# missing container, is false rather than an error, so callers under errexit
+# can branch on it with a plain if.
+container_running() {
+    local name="${1:-}"
+    [ -n "${name}" ] || return 1
+    local state
+    state="$(${DOCKER} inspect --format '{{.State.Running}}' "${name}" 2>/dev/null || true)"
+    [ "${state}" = "true" ]
 }
 
 # PR number of the running preview with the largest creation timestamp, or

--- a/deploy/preview/lib.sh
+++ b/deploy/preview/lib.sh
@@ -45,6 +45,30 @@ PREVIEW_REPO="${PREVIEW_REPO:-RTXteam/RTX}"
 PREVIEW_BUILD_CONTEXT="${PREVIEW_BUILD_CONTEXT:-${REPO_ROOT}/DockerBuild}"
 PREVIEW_DOCKERFILE="${PREVIEW_DOCKERFILE:-${PREVIEW_BUILD_CONTEXT}/CICD-Dockerfile}"
 
+# Resource guards. One preview must never be able to take the whole box down.
+# The memory ceiling for a preview container: an ARAX container idles at about
+# 400 MB and was measured at 1889 MiB peak while answering queries, so 2g is
+# the floor here. Anything lower gets the container killed by the kernel in
+# the middle of a query.
+PREVIEW_MEMORY_LIMIT="${PREVIEW_MEMORY_LIMIT:-2g}"
+# CPU ceiling for a preview container. The host has 2 vCPUs and a pathfinder
+# query saturates both, so 1.5 leaves half a core for nginx and the runner.
+PREVIEW_CPU_LIMIT="${PREVIEW_CPU_LIMIT:-1.5}"
+# How many previews may live on the host at once. A redeploy of a pull request
+# that already has a container never counts against this.
+PREVIEW_MAX_ACTIVE="${PREVIEW_MAX_ACTIVE:-3}"
+# Refuse to build below this much free space on the docker root. One preview
+# image is about 3.94 GB.
+PREVIEW_MIN_FREE_DISK_GB="${PREVIEW_MIN_FREE_DISK_GB:-10}"
+# Refuse to start a container below this much available memory on the host.
+PREVIEW_MIN_FREE_RAM_MB="${PREVIEW_MIN_FREE_RAM_MB:-2048}"
+
+# Document root of the status page served at /previews/. The per-PR files the
+# page embeds live under ${PREVIEW_WEB_ROOT}/data/<PR>/.
+PREVIEW_WEB_ROOT="${PREVIEW_WEB_ROOT:-/var/www/arax-preview}"
+# Full deploy logs, one file per deploy run, pruned by gc.sh after 30 days.
+PREVIEW_LOG_DIR="${PREVIEW_LOG_DIR:-/var/log/arax-preview}"
+
 # The runner user on cicd.rtx.ai has passwordless sudo and the existing
 # pytest.yml workflow already shells out to "sudo docker", so we do the same.
 DOCKER="${DOCKER:-sudo docker}"
@@ -55,12 +79,18 @@ SUDO="${SUDO-sudo}"
 export PREVIEW_PATH_PREFIX PREVIEW_PORT_BASE PREVIEW_NGINX_DIR \
     PREVIEW_PUBLIC_BASE_URL PREVIEW_DB_DIR PREVIEW_CONFIG_SECRETS \
     PREVIEW_TTL_DAYS PREVIEW_HEALTH_TIMEOUT PREVIEW_FAST_HEALTH_TIMEOUT PREVIEW_REPO \
-    PREVIEW_BUILD_CONTEXT PREVIEW_DOCKERFILE DOCKER SUDO
+    PREVIEW_BUILD_CONTEXT PREVIEW_DOCKERFILE DOCKER SUDO \
+    PREVIEW_MEMORY_LIMIT PREVIEW_CPU_LIMIT PREVIEW_MAX_ACTIVE \
+    PREVIEW_MIN_FREE_DISK_GB PREVIEW_MIN_FREE_RAM_MB \
+    PREVIEW_WEB_ROOT PREVIEW_LOG_DIR
 
 # Name of the shared autocomplete snippet. Leading underscore keeps it sorted
 # ahead of the numeric per-PR files, which is only cosmetic.
 PREVIEW_RTXCOMPLETE_CONF="${PREVIEW_NGINX_DIR}/_rtxcomplete.conf"
-export PREVIEW_RTXCOMPLETE_CONF
+# The snippet that serves the status page at /previews/ and redirects the bare
+# root to it. Also sorted ahead of the per-PR files by its leading underscore.
+PREVIEW_STATUS_CONF="${PREVIEW_NGINX_DIR}/_previews.conf"
+export PREVIEW_RTXCOMPLETE_CONF PREVIEW_STATUS_CONF
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -231,4 +261,279 @@ newest_preview_pr() {
         | sort -k1,1n \
         | tail -n 1 \
         | awk '{print $2}' || true
+}
+
+# ---------------------------------------------------------------------------
+# Status page data files
+# ---------------------------------------------------------------------------
+
+# Directory the status page reads the per-PR reports from.
+preview_data_dir() {
+    local pr="${1:-}"
+    require_int "${pr}" "PR number"
+    printf '%s/data/%s\n' "${PREVIEW_WEB_ROOT}" "${pr}"
+}
+
+# write_preview_data <PR> <filename>
+# Copies stdin into the per-PR data directory the status page embeds. Best
+# effort on purpose: these files are a convenience, so a failure is logged as
+# a warning and never propagated to the caller. Stdin is always drained, even
+# when nothing is written, so the producer never sees a broken pipe.
+write_preview_data() {
+    local pr="${1:-}"
+    local name="${2:-}"
+    local dir
+    case "${pr}" in
+        ''|*[!0-9]*)
+            cat >/dev/null
+            return 0
+            ;;
+    esac
+    if [ -z "${name}" ] || [ -z "${PREVIEW_WEB_ROOT}" ]; then
+        cat >/dev/null
+        return 0
+    fi
+    dir="${PREVIEW_WEB_ROOT}/data/${pr}"
+    if ! ${SUDO} mkdir -p "${dir}" 2>/dev/null; then
+        cat >/dev/null
+        log "WARNING: could not create ${dir}, not saving ${name}"
+        return 0
+    fi
+    # World readable, because the page generator and nginx both read these as
+    # somebody other than root.
+    ${SUDO} chmod 755 "${PREVIEW_WEB_ROOT}" "${PREVIEW_WEB_ROOT}/data" "${dir}" 2>/dev/null || true
+    if ! ${SUDO} tee "${dir}/${name}" >/dev/null; then
+        log "WARNING: could not write ${dir}/${name}"
+        return 0
+    fi
+    ${SUDO} chmod 644 "${dir}/${name}" 2>/dev/null || true
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Status page
+# ---------------------------------------------------------------------------
+
+# write_status_page
+# Regenerates ${PREVIEW_WEB_ROOT}/index.html from the docker labels of every
+# preview container on the box, plus whatever per-PR report files exist at
+# generation time. Called by deploy.sh, teardown.sh, gc.sh and the installer.
+# Best effort throughout: the page is a convenience and must never be able to
+# fail a deploy or a teardown.
+write_status_page() {
+    if [ -z "${PREVIEW_WEB_ROOT}" ]; then
+        return 0
+    fi
+    if ! ${SUDO} mkdir -p "${PREVIEW_WEB_ROOT}/data" 2>/dev/null; then
+        log "WARNING: could not create ${PREVIEW_WEB_ROOT}, skipping the status page"
+        return 0
+    fi
+    ${SUDO} chmod 755 "${PREVIEW_WEB_ROOT}" "${PREVIEW_WEB_ROOT}/data" 2>/dev/null || true
+
+    local rows html
+    # One tab separated line per preview: pr, branch, sha, created, state.
+    rows="$(${DOCKER} ps -a --filter 'label=arax.preview=true' \
+        --format '{{.Label "arax.preview.pr"}}\t{{.Label "arax.preview.branch"}}\t{{.Label "arax.preview.sha"}}\t{{.Label "arax.preview.created"}}\t{{.State}}' \
+        2>/dev/null || true)"
+
+    if ! html="$(printf '%s\n' "${rows}" | python3 -c '
+import html as html_module
+import os
+import sys
+import time
+
+web_root = os.environ.get("PREVIEW_WEB_ROOT", "/var/www/arax-preview")
+prefix = os.environ.get("PREVIEW_PATH_PREFIX", "")
+base_url = os.environ.get("PREVIEW_PUBLIC_BASE_URL", "https://cicd.rtx.ai").rstrip("/")
+repo = os.environ.get("PREVIEW_REPO", "RTXteam/RTX")
+ttl = os.environ.get("PREVIEW_TTL_DAYS", "7")
+
+# name on disk, label in the expander
+DATA_FILES = [
+    ("deploy-log.txt", "deploy log"),
+    ("smoke.md", "smoke test"),
+    ("pytest.md", "pytest"),
+    ("queries.md", "live queries"),
+]
+# A runaway file must not turn the page into a 40 MB download.
+MAX_EMBED_BYTES = 200000
+
+
+def esc(value):
+    return html_module.escape(str(value), quote=True)
+
+
+def read_data_file(pr, name):
+    path = os.path.join(web_root, "data", str(pr), name)
+    try:
+        with open(path, "r", errors="replace") as handle:
+            text = handle.read()
+    except Exception:
+        return None
+    if len(text) > MAX_EMBED_BYTES:
+        text = "[truncated]\n" + text[-MAX_EMBED_BYTES:]
+    return text
+
+
+previews = []
+for line in sys.stdin.read().splitlines():
+    if not line.strip():
+        continue
+    fields = line.split("\t")
+    if len(fields) < 5:
+        # Older docker builds hand the format string through without turning
+        # the escape into a real tab.
+        fields = line.split("\\t")
+    while len(fields) < 5:
+        fields.append("")
+    pr, branch, sha, created, state = [item.strip() for item in fields[:5]]
+    if not pr.isdigit():
+        continue
+    if created.isdigit():
+        created_text = time.strftime("%Y-%m-%d %H:%M UTC", time.gmtime(int(created)))
+    else:
+        created_text = "unknown"
+    previews.append(
+        {
+            "pr": pr,
+            "branch": branch or "unknown",
+            "sha": sha,
+            "created": created_text,
+            "state": state or "unknown",
+        }
+    )
+previews.sort(key=lambda item: int(item["pr"]))
+
+out = []
+out.append("<!DOCTYPE html>")
+out.append("<html lang=\"en\">")
+out.append("<head>")
+out.append("<meta charset=\"utf-8\">")
+out.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
+out.append("<title>ARAX preview host</title>")
+out.append("<style>")
+out.append(""":root { color-scheme: dark; }
+* { box-sizing: border-box; }
+body { margin: 0; background: #15171a; color: #d7dae0;
+       font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+.wrap { max-width: 920px; margin: 0 auto; padding: 34px 20px 64px; }
+h1 { font-size: 22px; margin: 0 0 10px; font-weight: 600; }
+p.lede { color: #98a0ab; margin: 0 0 26px; max-width: 70ch; }
+a { color: #7bb2f0; }
+a:hover { color: #a9cdf7; }
+.card { border: 1px solid #2b3037; border-radius: 8px; background: #1b1e23;
+        padding: 16px 18px; margin: 0 0 16px; }
+.card h2 { font-size: 17px; font-weight: 600; margin: 0 0 12px;
+           display: flex; align-items: center; gap: 9px; }
+.dot { width: 10px; height: 10px; border-radius: 50%; background: #59616c;
+       display: inline-block; flex: none; }
+.dot.ok { background: #46a758; }
+.dot.bad { background: #d1444a; }
+dl { display: grid; grid-template-columns: 108px minmax(0, 1fr); gap: 3px 14px; margin: 0; }
+dt { color: #98a0ab; }
+dd { margin: 0; overflow-wrap: anywhere; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
+.running { color: #46a758; }
+.stopped { color: #d68b3c; }
+details { border-top: 1px solid #2b3037; margin-top: 10px; padding-top: 9px; }
+details + details { margin-top: 0; }
+summary { cursor: pointer; color: #98a0ab; font-size: 14px; }
+pre { overflow-x: auto; background: #101216; border: 1px solid #2b3037; border-radius: 6px;
+      padding: 10px 12px; font-size: 12px; line-height: 1.45; margin: 10px 0 4px;
+      white-space: pre-wrap; overflow-wrap: anywhere; }
+.empty { color: #98a0ab; border: 1px dashed #2b3037; border-radius: 8px; padding: 22px; text-align: center; }
+footer { color: #6d7681; font-size: 13px; border-top: 1px solid #2b3037;
+         margin-top: 30px; padding-top: 14px; }""")
+out.append("</style>")
+out.append("</head>")
+out.append("<body>")
+out.append("<div class=\"wrap\">")
+out.append("<h1>ARAX preview host</h1>")
+out.append(
+    "<p class=\"lede\">This is cicd.rtx.ai. Every card below is a per-PR preview deployment of "
+    "<a href=\"https://github.com/" + esc(repo) + "\">" + esc(repo) + "</a>, built from that pull "
+    "request and served from its own container. See <code>deploy/preview/README.md</code> in the "
+    "repository for how they are made and torn down. Previews are public, unauthenticated and "
+    "temporary: they are removed " + esc(ttl) + " days after they are deployed, or as soon as "
+    "their pull request closes.</p>"
+)
+
+if not previews:
+    out.append("<p class=\"empty\">No previews are deployed right now.</p>")
+
+for item in previews:
+    pr = item["pr"]
+    path = "/" + prefix + pr
+    url = base_url + path + "/"
+    status_path = path + "/api/arax/v1.4/status"
+    sha = item["sha"]
+    out.append("<div class=\"card\">")
+    out.append(
+        "<h2><span class=\"dot\" data-status=\"" + esc(status_path) + "\" title=\"health unknown\">"
+        "</span><a href=\"https://github.com/" + esc(repo) + "/pull/" + esc(pr) + "\">PR #"
+        + esc(pr) + "</a></h2>"
+    )
+    out.append("<dl>")
+    out.append("<dt>branch</dt><dd><code>" + esc(item["branch"]) + "</code></dd>")
+    if sha and sha != "unknown":
+        out.append(
+            "<dt>commit</dt><dd><a href=\"https://github.com/" + esc(repo) + "/commit/" + esc(sha)
+            + "\"><code>" + esc(sha[:7]) + "</code></a></dd>"
+        )
+    else:
+        out.append("<dt>commit</dt><dd><code>unknown</code></dd>")
+    out.append("<dt>created</dt><dd>" + esc(item["created"]) + "</dd>")
+    state_class = "running" if item["state"] == "running" else "stopped"
+    out.append("<dt>state</dt><dd class=\"" + state_class + "\">" + esc(item["state"]) + "</dd>")
+    out.append("<dt>preview</dt><dd><a href=\"" + esc(url) + "\">" + esc(url) + "</a></dd>")
+    out.append("</dl>")
+    for name, label in DATA_FILES:
+        body = read_data_file(pr, name)
+        if body is None:
+            continue
+        out.append("<details><summary>" + esc(label) + "</summary>")
+        out.append("<pre>" + esc(body.rstrip()) + "</pre>")
+        out.append("</details>")
+    out.append("</div>")
+
+out.append(
+    "<footer>Generated " + time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime())
+    + ". This page is rewritten on every deploy, on every teardown and by the nightly garbage "
+    "collection, so it can be up to a day behind a container that died on its own. The dots are "
+    "live and are checked by your browser when the page loads.</footer>"
+)
+out.append("</div>")
+out.append("<script>")
+out.append("""(function () {
+  if (typeof fetch !== "function") { return; }
+  var dots = document.querySelectorAll(".dot[data-status]");
+  Array.prototype.forEach.call(dots, function (dot) {
+    var options = {};
+    try { options.signal = AbortSignal.timeout(8000); } catch (error) { options = {}; }
+    fetch(dot.getAttribute("data-status"), options).then(function (response) {
+      dot.className = response.ok ? "dot ok" : "dot bad";
+      dot.title = "HTTP " + response.status;
+    }).catch(function (error) {
+      dot.className = "dot bad";
+      dot.title = "unreachable: " + error;
+    });
+  });
+})();""")
+out.append("</script>")
+out.append("</body>")
+out.append("</html>")
+
+sys.stdout.write("\n".join(out) + "\n")
+')"; then
+        log "WARNING: could not render the status page"
+        return 0
+    fi
+
+    if ! printf '%s\n' "${html}" | ${SUDO} tee "${PREVIEW_WEB_ROOT}/index.html" >/dev/null; then
+        log "WARNING: could not write ${PREVIEW_WEB_ROOT}/index.html"
+        return 0
+    fi
+    ${SUDO} chmod 644 "${PREVIEW_WEB_ROOT}/index.html" 2>/dev/null || true
+    log "wrote the status page ${PREVIEW_WEB_ROOT}/index.html"
+    return 0
 }

--- a/deploy/preview/lib.sh
+++ b/deploy/preview/lib.sh
@@ -57,9 +57,12 @@ PREVIEW_CPU_LIMIT="${PREVIEW_CPU_LIMIT:-1.5}"
 # How many previews may live on the host at once. A redeploy of a pull request
 # that already has a container never counts against this.
 PREVIEW_MAX_ACTIVE="${PREVIEW_MAX_ACTIVE:-3}"
-# Refuse to build below this much free space on the docker root. One preview
-# image is about 3.94 GB.
+# Refuse to build below this much free space on the docker root. The floor is
+# the larger of the absolute value and the percentage of the volume size, so
+# it scales with the host: one preview image is about 3.94 GB, and on the
+# 485 GB root of cicd.rtx.ai the percentage wins at about 48 GB.
 PREVIEW_MIN_FREE_DISK_GB="${PREVIEW_MIN_FREE_DISK_GB:-10}"
+PREVIEW_MIN_FREE_DISK_PCT="${PREVIEW_MIN_FREE_DISK_PCT:-10}"
 # Refuse to start a container below this much available memory on the host.
 PREVIEW_MIN_FREE_RAM_MB="${PREVIEW_MIN_FREE_RAM_MB:-2048}"
 
@@ -81,7 +84,7 @@ export PREVIEW_PATH_PREFIX PREVIEW_PORT_BASE PREVIEW_NGINX_DIR \
     PREVIEW_TTL_DAYS PREVIEW_HEALTH_TIMEOUT PREVIEW_FAST_HEALTH_TIMEOUT PREVIEW_REPO \
     PREVIEW_BUILD_CONTEXT PREVIEW_DOCKERFILE DOCKER SUDO \
     PREVIEW_MEMORY_LIMIT PREVIEW_CPU_LIMIT PREVIEW_MAX_ACTIVE \
-    PREVIEW_MIN_FREE_DISK_GB PREVIEW_MIN_FREE_RAM_MB \
+    PREVIEW_MIN_FREE_DISK_GB PREVIEW_MIN_FREE_DISK_PCT PREVIEW_MIN_FREE_RAM_MB \
     PREVIEW_WEB_ROOT PREVIEW_LOG_DIR
 
 # Name of the shared autocomplete snippet. Leading underscore keeps it sorted

--- a/deploy/preview/pytest_report.sh
+++ b/deploy/preview/pytest_report.sh
@@ -16,6 +16,7 @@ set -o nounset -o pipefail -o errexit
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "${SCRIPT_DIR}/lib.sh"
+preview_validate_env
 
 usage() {
     cat >&2 <<'USAGE_EOF'

--- a/deploy/preview/pytest_report.sh
+++ b/deploy/preview/pytest_report.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Run the ARAX test suite inside one preview container and print a short
+# Markdown report on stdout, which the workflow posts as its own pull request
+# comment. The raw pytest output goes to stderr, so the workflow log and the
+# uploaded artifact keep all of it.
+#
+# Usage: pytest_report.sh <PR> [PYTEST_ARGS]
+#
+# Exits with the exit code of pytest itself.
+#
+# Issue #2846.
+
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+usage() {
+    cat >&2 <<'USAGE_EOF'
+Usage: pytest_report.sh <PR> [PYTEST_ARGS]
+
+  PR           pull request number, for example 2853
+  PYTEST_ARGS  extra arguments for pytest as one string, for example
+               "-k test_ARAX_query". May be empty or left out, which runs the
+               whole suite.
+USAGE_EOF
+    exit 2
+}
+
+[ "$#" -ge 1 ] || usage
+case "${1}" in
+    -h|--help) usage ;;
+esac
+
+PR="$1"
+require_int "${PR}" "PR number"
+PYTEST_ARGS="${2:-}"
+
+CONTAINER="$(preview_container "${PR}")"
+TEST_DIR="/mnt/data/orangeboard/production/RTX/code/ARAX/test"
+
+if ! container_running "${CONTAINER}"; then
+    # the backticks are markdown around the container name, not a substitution
+    # shellcheck disable=SC2016
+    printf '**pytest:** not run, the container `%s` is not running\n' "${CONTAINER}"
+    exit 1
+fi
+
+PYTEST_LOG="$(mktemp)"
+trap 'rm -f "${PYTEST_LOG}"' EXIT
+
+log "running pytest inside ${CONTAINER} with args '${PYTEST_ARGS}'"
+
+# No -v. The suite is long and the summary line is what the report is built
+# from, so per test lines only make the artifact bigger.
+set +o errexit
+${DOCKER} exec "${CONTAINER}" bash -c "cd ${TEST_DIR} && pytest --disable-pytest-warnings ${PYTEST_ARGS}" \
+    > "${PYTEST_LOG}" 2>&1
+PYTEST_RC=$?
+set -o errexit
+
+# Everything pytest said, for the job log and the artifact.
+cat "${PYTEST_LOG}" >&2
+
+REPORT="$(PYTEST_RC="${PYTEST_RC}" python3 - "${PYTEST_LOG}" <<'PYTHON_EOF'
+import os
+import re
+import sys
+
+path = sys.argv[1]
+try:
+    rc = int(os.environ.get("PYTEST_RC", "1"))
+except ValueError:
+    rc = 1
+
+with open(path, "r", errors="replace") as handle:
+    lines = handle.read().splitlines()
+
+# The summary line pytest ends with looks like
+#   ===== 3 failed, 128 passed, 5 skipped, 2 warnings in 154.32s (0:02:34) =====
+# Read it from the bottom, because a test that prints something similar must
+# not win over the real one.
+COUNT_RE = re.compile(r"(\d+) (passed|failed|skipped|errors?|xfailed|xpassed)\b")
+DURATION_RE = re.compile(r"\bin ([0-9.]+s(?: \([^)]*\))?)")
+
+counts = {}
+duration = ""
+for line in reversed(lines):
+    stripped = line.strip().strip("=").strip()
+    found = COUNT_RE.findall(stripped)
+    when = DURATION_RE.search(stripped)
+    if found and when:
+        for number, word in found:
+            key = "error" if word.startswith("error") else word
+            counts[key] = counts.get(key, 0) + int(number)
+        duration = when.group(1)
+        break
+
+report = []
+if counts and duration:
+    parts = [
+        "%d passed" % counts.get("passed", 0),
+        "%d failed" % counts.get("failed", 0),
+        "%d skipped" % counts.get("skipped", 0),
+    ]
+    if counts.get("error", 0):
+        parts.append("%d errors" % counts["error"])
+    report.append("**pytest:** " + ", ".join(parts) + " in " + duration)
+else:
+    # A crashed collection, a killed container or an unknown pytest version.
+    report.append("**pytest:** exit %d" % rc)
+
+if rc != 0:
+    failed = [line.rstrip() for line in lines
+              if line.startswith("FAILED ") or line.startswith("ERROR ")]
+    body = failed + ["", "--- last 80 lines of output ---", ""] + [line.rstrip() for line in lines[-80:]]
+    # chr(96) keeps a literal backtick out of this file. bash cannot parse a
+    # backtick inside a heredoc that sits inside a command substitution.
+    fence = chr(96) * 3
+    report.append("")
+    report.append("<details><summary>failed tests and last 80 lines</summary>")
+    report.append("")
+    report.append(fence)
+    # A fence inside the output would end the block early.
+    report.extend([line.replace(fence, "'''") for line in body])
+    report.append(fence)
+    report.append("")
+    report.append("</details>")
+
+sys.stdout.write("\n".join(report) + "\n")
+PYTHON_EOF
+)"
+
+printf '%s\n' "${REPORT}"
+printf '%s\n' "${REPORT}" | write_preview_data "${PR}" "pytest.md"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "${REPORT}" >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+exit "${PYTEST_RC}"

--- a/deploy/preview/query_smoke.sh
+++ b/deploy/preview/query_smoke.sh
@@ -21,6 +21,7 @@ set -o nounset -o pipefail -o errexit
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "${SCRIPT_DIR}/lib.sh"
+preview_validate_env
 
 usage() {
     cat >&2 <<'USAGE_EOF'

--- a/deploy/preview/query_smoke.sh
+++ b/deploy/preview/query_smoke.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+#
+# Run the four example queries the ARAX UI ships with against one preview and
+# print a Markdown table on stdout, which the workflow posts as its own pull
+# request comment.
+#
+# The payloads are read out of code/UI/interactive/rtx.js, so this always
+# tests exactly what the Try an example buttons in the UI put in the box. The
+# requests go through the public URL, which means nginx on the host and apache
+# in the container are on the path and get tested too.
+#
+# Usage: query_smoke.sh <PR>
+#
+# The report is informational and the script exits 0 even when queries fail.
+# Only a usage error exits non-zero.
+#
+# Issue #2846.
+
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+usage() {
+    cat >&2 <<'USAGE_EOF'
+Usage: query_smoke.sh <PR>
+
+  PR  pull request number, for example 2853
+
+Environment:
+  PREVIEW_UI_RTXJS    rtx.js the example payloads are read from. Defaults to
+                      the copy in this checkout. The workflow points it at the
+                      pull request head, so a pull request that changes the
+                      examples is tested with its own.
+  PREVIEW_QUERY_BASE  base URL the queries are sent to. Defaults to the public
+                      preview URL for this pull request.
+USAGE_EOF
+    exit 2
+}
+
+[ "$#" -ge 1 ] || usage
+case "${1}" in
+    -h|--help) usage ;;
+esac
+
+PR="$1"
+require_int "${PR}" "PR number"
+
+PREVIEW_UI_RTXJS="${PREVIEW_UI_RTXJS:-${REPO_ROOT}/code/UI/interactive/rtx.js}"
+PREVIEW_QUERY_BASE="${PREVIEW_QUERY_BASE:-$(preview_url "${PR}")}"
+# Trailing slash off, because the path below brings its own.
+QUERY_URL="${PREVIEW_QUERY_BASE%/}/api/arax/v1.4/query"
+
+export PREVIEW_UI_RTXJS PREVIEW_QUERY_BASE
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+# kind, label for the table, timeout in seconds. The pathfinder query was
+# measured at 90 seconds on this host, the other three at 3 to 5 seconds.
+QUERIES=(
+    "JSON1|interacts_with (CHEBI:46195)|240"
+    "JSON2|treats inferred (MONDO:0015564)|240"
+    "JSON3|affects qualified (NCBIGene:1576)|240"
+    "PATH1|pathfinder (MONDO:0005011 to MONDO:0005180)|400"
+)
+
+log "reading the example query graphs from ${PREVIEW_UI_RTXJS}"
+
+# The extractor writes one ready to post request body per example into the
+# work directory and prints "<kind> ok <node count>" or "<kind> fail <reason>"
+# for each. A payload it cannot read is reported and skipped, never fatal.
+EXTRACTION="$(QUERY_WORK_DIR="${WORK_DIR}" python3 - <<'PYTHON_EOF'
+import json
+import os
+import re
+import sys
+
+path = os.environ.get("PREVIEW_UI_RTXJS", "")
+work = os.environ.get("QUERY_WORK_DIR", "")
+kinds = ["JSON1", "JSON2", "JSON3", "PATH1"]
+
+ESCAPES = {
+    "n": "\n",
+    "t": "\t",
+    "r": "\r",
+    "b": "\b",
+    "f": "\f",
+    "0": "\0",
+    "'": "'",
+    "\"": "\"",
+    "\\": "\\",
+    "/": "/",
+}
+ASSIGNMENT = re.compile(r"\.value\s*=\s*'")
+
+
+def report(kind, state, detail):
+    sys.stdout.write(kind + "\t" + state + "\t" + detail + "\n")
+
+
+try:
+    with open(path, "r", errors="replace") as handle:
+        source = handle.read()
+except Exception as error:
+    for kind in kinds:
+        report(kind, "fail", "cannot read the UI source: %s" % error)
+    sys.exit(0)
+
+
+def js_string_after(marker_index):
+    """The single quoted JavaScript string assigned to .value after an index."""
+    found = ASSIGNMENT.search(source, marker_index)
+    if found is None:
+        return None, "no .value assignment follows the case"
+    index = found.end()
+    out = []
+    while index < len(source):
+        char = source[index]
+        if char == "\\":
+            nxt = source[index + 1:index + 2]
+            out.append(ESCAPES.get(nxt, nxt))
+            index += 2
+            continue
+        if char == "'":
+            return "".join(out), ""
+        if char == "\n":
+            return None, "the string is not terminated on one line"
+        out.append(char)
+        index += 1
+    return None, "the string is not terminated"
+
+
+for kind in kinds:
+    marker = 'type == "' + kind + '"'
+    at = source.find(marker)
+    if at < 0:
+        report(kind, "fail", "no branch for " + kind + " in pasteExample")
+        continue
+    text, problem = js_string_after(at)
+    if text is None:
+        report(kind, "fail", problem)
+        continue
+    try:
+        graph = json.loads(text)
+    except Exception as error:
+        report(kind, "fail", "the payload is not valid JSON: %s" % error)
+        continue
+    if not isinstance(graph, dict):
+        report(kind, "fail", "the payload is not a query graph object")
+        continue
+    # The envelope the UI builds around the box contents before it posts.
+    body = {"message": {"query_graph": graph}}
+    try:
+        with open(os.path.join(work, kind + ".body.json"), "w") as handle:
+            json.dump(body, handle)
+    except Exception as error:
+        report(kind, "fail", "could not write the request body: %s" % error)
+        continue
+    report(kind, "ok", str(len(graph.get("nodes") or {})))
+PYTHON_EOF
+)"
+
+printf '%s\n' "${EXTRACTION}" >&2
+
+ROWS=()
+DEGRADED=0
+
+# Everything the queries are asked about, in one place, so the row builder
+# below stays readable.
+for entry in "${QUERIES[@]}"; do
+    KIND="${entry%%|*}"
+    REST="${entry#*|}"
+    LABEL="${REST%%|*}"
+    TIMEOUT="${REST##*|}"
+
+    STATE="$(printf '%s\n' "${EXTRACTION}" | awk -F'\t' -v k="${KIND}" '$1 == k {print $2; exit}')"
+    DETAIL="$(printf '%s\n' "${EXTRACTION}" | awk -F'\t' -v k="${KIND}" '$1 == k {print $3; exit}')"
+
+    if [ "${STATE}" != "ok" ]; then
+        log "${KIND}: payload extraction failed, ${DETAIL}"
+        ROWS+=("| ⚠ ${LABEL} | - | - | - | - | payload extraction failed |")
+        DEGRADED=$(( DEGRADED + 1 ))
+        continue
+    fi
+
+    log "${KIND}: posting to ${QUERY_URL} with a ${TIMEOUT}s timeout"
+    BODY_FILE="${WORK_DIR}/${KIND}.body.json"
+    RESPONSE_FILE="${WORK_DIR}/${KIND}.response.json"
+    STARTED="$(date -u '+%s')"
+    CODE="$(curl -sS -m "${TIMEOUT}" \
+        -o "${RESPONSE_FILE}" \
+        -w '%{http_code}' \
+        -H 'Content-Type: application/json' \
+        --data-binary "@${BODY_FILE}" \
+        "${QUERY_URL}" 2>>"${WORK_DIR}/curl.err" || true)"
+    ELAPSED=$(( $(date -u '+%s') - STARTED ))
+    case "${CODE}" in
+        [1-5][0-9][0-9]) : ;;
+        *) CODE="000" ;;
+    esac
+
+    PARSED="$(python3 - "${RESPONSE_FILE}" <<'PYTHON_EOF'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", errors="replace") as handle:
+        data = json.load(handle)
+except Exception:
+    sys.stdout.write("-\t-\t-\tno parsable response body\n")
+    sys.exit(0)
+
+if not isinstance(data, dict):
+    sys.stdout.write("-\t-\t-\tthe response is not a TRAPI object\n")
+    sys.exit(0)
+
+message = data.get("message") or {}
+if not isinstance(message, dict):
+    message = {}
+graph = message.get("knowledge_graph") or {}
+if not isinstance(graph, dict):
+    graph = {}
+results = message.get("results") or []
+nodes = graph.get("nodes") or {}
+edges = graph.get("edges") or {}
+status = data.get("status")
+if not isinstance(status, str):
+    status = ""
+# The table has to survive whatever the server put in there.
+status = status.replace("|", "/").replace("\n", " ").replace("\r", " ").strip()
+sys.stdout.write(
+    "%d\t%d\t%d\t%s\n" % (len(results), len(nodes), len(edges), status[:60] or "-")
+)
+PYTHON_EOF
+)"
+
+    RESULTS="$(printf '%s\n' "${PARSED}" | awk -F'\t' 'NR == 1 {print $1}')"
+    NODES="$(printf '%s\n' "${PARSED}" | awk -F'\t' 'NR == 1 {print $2}')"
+    EDGES="$(printf '%s\n' "${PARSED}" | awk -F'\t' 'NR == 1 {print $3}')"
+    STATUS="$(printf '%s\n' "${PARSED}" | awk -F'\t' 'NR == 1 {print $4}')"
+
+    MARK=""
+    # No results is a failure of the preview even when the HTTP call worked,
+    # which is the whole reason this report exists next to the smoke test.
+    if [ "${CODE}" != "200" ] || [ "${RESULTS}" = "0" ] || [ "${RESULTS}" = "-" ]; then
+        MARK="⚠ "
+        DEGRADED=$(( DEGRADED + 1 ))
+    fi
+    log "${KIND}: HTTP ${CODE} in ${ELAPSED}s, ${RESULTS} result(s), status ${STATUS}"
+    ROWS+=("| ${MARK}${LABEL} | ${CODE} | ${ELAPSED} | ${RESULTS} | ${NODES}/${EDGES} | ${STATUS} |")
+done
+
+render_report() {
+    printf '| query | HTTP | s | results | KG nodes/edges | status |\n'
+    printf '| --- | --- | --- | --- | --- | --- |\n'
+    local row
+    for row in "${ROWS[@]}"; do
+        printf '%s\n' "${row}"
+    done
+    printf '\n'
+    # the backticks are markdown around the URL, not a substitution
+    # shellcheck disable=SC2016
+    printf 'Posted to `%s`. Reference timings from a healthy preview on this host: about 3, 5, 4 and 90 seconds in that order. A row is marked ⚠ when the call did not answer 200 or came back with no results.\n' "${QUERY_URL}"
+}
+
+render_report
+render_report | write_preview_data "${PR}" "queries.md"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    render_report >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+if [ "${DEGRADED}" -gt 0 ]; then
+    log "${DEGRADED} of ${#QUERIES[@]} example queries came back degraded for PR ${PR}"
+else
+    log "all ${#QUERIES[@]} example queries answered for PR ${PR}"
+fi
+
+# Informational by design: a slow or empty answer is worth reading, not worth
+# turning the deploy red.
+exit 0

--- a/deploy/preview/smoke.sh
+++ b/deploy/preview/smoke.sh
@@ -100,6 +100,8 @@ finish() {
     if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
         render_report >> "${GITHUB_STEP_SUMMARY}"
     fi
+    # Same table where the status page at /previews/ can show it.
+    render_report | write_preview_data "${PR}" "smoke.md"
     if [ "${FAILURES}" -gt 0 ]; then
         log "${FAILURES} smoke check(s) failed for PR ${PR}"
         exit 1

--- a/deploy/preview/smoke.sh
+++ b/deploy/preview/smoke.sh
@@ -16,6 +16,7 @@ set -o nounset -o pipefail -o errexit
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "${SCRIPT_DIR}/lib.sh"
+preview_validate_env
 
 usage() {
     cat >&2 <<'USAGE_EOF'

--- a/deploy/preview/teardown.sh
+++ b/deploy/preview/teardown.sh
@@ -89,6 +89,22 @@ else
     log "WARNING: ${PREVIEW_NGINX_DIR} does not exist, skipping the nginx cleanup"
 fi
 
+# The per-PR files the status page embeds. Cosmetic, so a failure here is a
+# warning and not a teardown failure.
+DATA_DIR="$(preview_data_dir "${PR}")"
+if ${SUDO} test -d "${DATA_DIR}"; then
+    if ${SUDO} rm -rf "${DATA_DIR}"; then
+        REMOVED+=("status page data ${DATA_DIR}")
+    else
+        log "WARNING: could not remove ${DATA_DIR}"
+    fi
+else
+    log "no status page data ${DATA_DIR}"
+fi
+
+# The preview is gone, so the page must stop advertising it.
+write_status_page
+
 if [ "${#REMOVED[@]}" -gt 0 ]; then
     printf 'Removed for PR %s:\n' "${PR}"
     for item in "${REMOVED[@]}"; do

--- a/deploy/preview/teardown.sh
+++ b/deploy/preview/teardown.sh
@@ -12,6 +12,7 @@ set -o nounset -o pipefail -o errexit
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "${SCRIPT_DIR}/lib.sh"
+preview_validate_env
 
 [ "$#" -ge 1 ] || { printf 'Usage: teardown.sh <PR>\n' >&2; exit 2; }
 


### PR DESCRIPTION
 - added chronological github issue commenting instead of editing the old one
 - fast redeploy (instead of rebuilding the docker container we just restart the service on new commit in the PR)
 - added guard to check for the number of deployed previews, and reject if cicd.rtx.ai has 3 previews deployed already (to avoid the limit overwhelm OOMs)
 - added disk guard 10% of the total disk space
 
 #2846 