### PR TITLE
#2828 Retriever URL follows ARAX maturity

### DIFF
--- a/code/ARAX/ARAXQuery/Expand/kp_info_cacher.py
+++ b/code/ARAX/ARAXQuery/Expand/kp_info_cacher.py
@@ -108,9 +108,6 @@ class KPInfoCacher:
                 # Captures an override if one is in place; otherwise server is read from our SmartAPI yaml/JSON
                 raw_url = self.rtx_config.plover_url
 
-            if kp_smart_api_registration["infores_name"] == "infores:retriever":
-                raw_url = "https://retriever.ci.transltr.io"
-
             # Remove any trailing slashes
             return raw_url.strip("/") if isinstance(raw_url, str) else raw_url
         else:


### PR DESCRIPTION
Today the issue was raised that ARAX doesn't hit the test instance of the Retriever 
<img width="2452" height="134" alt="image" src="https://github.com/user-attachments/assets/9b157175-08cc-4944-8e93-7e7bbf690d8d" />

This issue comes from the earlier commit where the Retriever endpoint was overwritten: 07f9133aa

The one thing that was missing on the Retriever side though is that the test endpoint wasn't registered in the SmartAPI. I have requested Willow to register it.

Willow registered the testing server in SmartAPI today 8/29, so the CI hardcode from 07f9133aa is no longer needed. 

After reverting the overwritten endpoint I verified: smartapi.py get_kps -m testing returns retriever.test.transltr.io, kp_info_cacher rebuilds, 3 expand tests pass locally. Production server is still not registered, ARAX prod will log Retriever as excluded by maturity until DOGSURF adds it. 