### PR TITLE
Bind overlay edges to results in a single pass (#2879)

### DIFF
--- a/code/ARAX/ARAXQuery/Overlay/compute_ngd.py
+++ b/code/ARAX/ARAXQuery/Overlay/compute_ngd.py
@@ -110,6 +110,7 @@ class ComputeNGD:
                     canonicalized_curie_lookup = self._get_canonical_curies_map(list(involved_curies))
                     self.load_curie_to_pmids_data(canonicalized_curie_lookup.values())
                     added_flag = False  # check to see if any edges where added
+                    kedge_keys_by_node_pair = {}  # bound to results in one pass once the loop finishes
                     self.response.debug(f"Looping through {len(node_pairs_to_evaluate)} node pairs and calculating NGD values")
                     # iterate over all pairs of these nodes, add the virtual edge, decorate with the correct attribute
                     for (subject_curie, object_curie) in self._order_node_pairs(node_pairs_to_evaluate,
@@ -214,10 +215,9 @@ class ComputeNGD:
                             edge.qedge_keys = qedge_keys
                             self.message.knowledge_graph.edges[id] = edge
 
-                            #FW: check if results exist then modify them with the ngd edge
-                            # import pdb;pdb.set_trace()
-                            if self.message.results is not None and len(self.message.results) > 0:
-                                ou.update_results_with_overlay_edge(subject_knode_key=subject_key, object_knode_key=object_key, kedge_key=id, message=self.message, log=self.response)
+                            kedge_keys_by_node_pair[(subject_key, object_key)] = id
+
+                    ou.update_results_with_overlay_edges(kedge_keys_by_node_pair, self.message, self.response)
 
                     # Now add a q_edge the query_graph since I've added an extra edge to the KG
                     if added_flag:
@@ -253,6 +253,7 @@ class ComputeNGD:
             canonicalized_curie_lookup = self._get_canonical_curies_map(list(involved_curies))
             self.load_curie_to_pmids_data(canonicalized_curie_lookup.values())
             added_flag = False  # check to see if any edges where added
+            kedge_keys_by_node_pair = {}  # bound to results in one pass once the loop finishes
             self.response.debug(f"Looping through {len(node_pairs_to_evaluate)} node pairs and calculating NGD values")
             # iterate over all pairs of these nodes, add the virtual edge, decorate with the correct attribute
             for (subject_curie, object_curie) in self._order_node_pairs(node_pairs_to_evaluate,
@@ -357,10 +358,9 @@ class ComputeNGD:
                     edge.qedge_keys = qedge_keys
                     self.message.knowledge_graph.edges[id] = edge
 
-                    #FW: check if results exist then modify them with the ngd edge
-                    # import pdb;pdb.set_trace()
-                    if self.message.results is not None and len(self.message.results) > 0:
-                        ou.update_results_with_overlay_edge(subject_knode_key=subject_key, object_knode_key=object_key, kedge_key=id, message=self.message, log=self.response)
+                    kedge_keys_by_node_pair[(subject_key, object_key)] = id
+
+            ou.update_results_with_overlay_edges(kedge_keys_by_node_pair, self.message, self.response)
 
             # Now add a q_edge the query_graph since I've added an extra edge to the KG
             if added_flag:

--- a/code/ARAX/ARAXQuery/Overlay/overlay_utilities.py
+++ b/code/ARAX/ARAXQuery/Overlay/overlay_utilities.py
@@ -4,7 +4,8 @@ import itertools
 import os
 import sys
 import traceback
-from typing import Optional
+from collections import defaultdict
+from typing import NamedTuple, Optional
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__))+"/../../../UI/OpenAPI/python-flask-server/")
 from openapi_server.models.response import Response
@@ -99,25 +100,70 @@ def determine_virtual_qedge_option_group(subject_qnode_key: str, object_qnode_ke
     else:
         return None
 
-def update_results_with_overlay_edge(subject_knode_key: str, object_knode_key: str, kedge_key: str, message: Message, log: ARAXResponse, reasoner_id: str="infores:arax"):
+class _BindingPlace(NamedTuple):
+    """One spot an overlay edge could be bound: one analysis's bindings for one qedge of one result."""
+    edge_bindings: list       # the live list an overlay edge gets appended to
+    covered_curies: set       # curies bound to that qedge's subject and object in this result
+    bound_kedge_keys: set     # edge keys already bound here
+
+
+def update_results_with_overlay_edges(kedge_keys_by_node_pair: dict[tuple[str, str], str], message: Message, log: ARAXResponse, reasoner_id: str="infores:arax"):
+    """
+    Bind each overlay edge to every result whose bound nodes it connects.
+
+    kedge_keys_by_node_pair maps a (subject curie, object curie) pair to the key of the overlay
+    edge that was built for that pair. A caller creating many overlay edges should collect them
+    and call this once instead of calling update_results_with_overlay_edge() per edge, because
+    the results are walked a single time here: the cost stops growing with the edge count.
+    """
+    if not kedge_keys_by_node_pair or not message.results:
+        return
     try:
-        new_edge_binding = EdgeBinding(id=kedge_key, attributes=[])
+        qedges = message.query_graph.edges
+
+        # Walk the results once, recording every place an overlay edge could be bound, indexed by
+        # covered curie so that each overlay edge only has to examine the relevant places.
+        binding_places_by_curie: defaultdict[str, list[_BindingPlace]] = defaultdict(list)
         for result in message.results:
             for analysis in result.analyses:
                 if reasoner_id != analysis.resource_id:
                     continue
-                for qedge_key in analysis.edge_bindings.keys():
-                    if kedge_key not in set([x.id for x in analysis.edge_bindings[qedge_key]]):
-                        if qedge_key not in message.query_graph.edges:
-                            log.warning("Encountered a result edge binding which does not exist in the query graph")
-                            continue
-                        subject_nodes = [x.id for x in result.node_bindings[message.query_graph.edges[qedge_key].subject]]
-                        object_nodes = [x.id for x in result.node_bindings[message.query_graph.edges[qedge_key].object]]
-                        result_nodes = set(subject_nodes).union(set(object_nodes))
-                        if subject_knode_key in result_nodes and object_knode_key in result_nodes:
-                            analysis.edge_bindings[qedge_key].append(new_edge_binding)
+                for qedge_key, edge_bindings in analysis.edge_bindings.items():
+                    qedge = qedges.get(qedge_key)
+                    if qedge is None:
+                        # Warned once per affected result/analysis/qedge: the volume of these is
+                        # itself the signal that something upstream has gone wrong.
+                        log.warning("Encountered a result edge binding which does not exist in the query graph")
+                        continue
+                    covered_curies = {binding.id for binding in result.node_bindings[qedge.subject]}
+                    covered_curies |= {binding.id for binding in result.node_bindings[qedge.object]}
+                    binding_place = _BindingPlace(edge_bindings, covered_curies,
+                                                  {binding.id for binding in edge_bindings})
+                    for curie in covered_curies:
+                        binding_places_by_curie[curie].append(binding_place)
+
+        # A place only qualifies if it covers both endpoints of the edge, so scan whichever
+        # endpoint is indexed in fewer places and confirm the other one by membership.
+        for (subject_knode_key, object_knode_key), kedge_key in kedge_keys_by_node_pair.items():
+            subject_places = binding_places_by_curie.get(subject_knode_key)
+            object_places = binding_places_by_curie.get(object_knode_key)
+            if not subject_places or not object_places:
+                continue
+            if len(subject_places) <= len(object_places):
+                places_to_scan, curie_to_confirm = subject_places, object_knode_key
+            else:
+                places_to_scan, curie_to_confirm = object_places, subject_knode_key
+            new_edge_binding = EdgeBinding(id=kedge_key, attributes=[])
+            for place in places_to_scan:
+                if curie_to_confirm in place.covered_curies and kedge_key not in place.bound_kedge_keys:
+                    place.edge_bindings.append(new_edge_binding)
+                    place.bound_kedge_keys.add(kedge_key)
     except Exception:
         tb = traceback.format_exc()
-        log.error(f"Error encountered when modifying results with overlay edge (subject_knode_key)-kedge_key-(object_knode_key):\n{tb}",
+        log.error(f"Error encountered when modifying results with overlay edges:\n{tb}",
                     error_code="UncaughtError")
+
+
+def update_results_with_overlay_edge(subject_knode_key: str, object_knode_key: str, kedge_key: str, message: Message, log: ARAXResponse, reasoner_id: str="infores:arax"):
+    update_results_with_overlay_edges({(subject_knode_key, object_knode_key): kedge_key}, message, log, reasoner_id)
 


### PR DESCRIPTION
update_results_with_overlay_edge() rescanned every result on each call, so the cost of attaching overlay edges grew with the number of edges created. The NGD virtual-edge `for` loops now collect the edges they build and bind them all at once through a new update_results_with_overlay_edges(), which traverses the results once and indexes each binding site by the curies it covers.

The per-edge function is kept as a thin wrapper over the batched one, so the other overlay modules are unaffected (i.e. future work if they ever get called frequently).


Claude-Session: https://claude.ai/code/session_01Aqed19AGvUr2yjBtfFLDs3

For issue #2879 